### PR TITLE
Fix several formation macro, auto-accept, movement cancellation, and auto-login issues

### DIFF
--- a/MasterOfPuppets/Commands/PluginCommandManager.cs
+++ b/MasterOfPuppets/Commands/PluginCommandManager.cs
@@ -178,7 +178,7 @@ public class PluginCommandManager : IDisposable {
                     }
                     break;
                 case "stopmoveinput":
-                    Plugin.SimpleInputMovement.StopMove();
+                    Plugin.StopAllMovementLocal();
                     break;
                 case "move": {
                         if (parsedArgs.Count < 2) {

--- a/MasterOfPuppets/Formations/FormationMoveAnchorMode.cs
+++ b/MasterOfPuppets/Formations/FormationMoveAnchorMode.cs
@@ -1,0 +1,6 @@
+namespace MasterOfPuppets.Formations;
+
+public enum FormationMoveAnchorMode {
+    Self,
+    Target,
+}

--- a/MasterOfPuppets/Game/GameDialog/GameDialogManager.AutoAccept.cs
+++ b/MasterOfPuppets/Game/GameDialog/GameDialogManager.AutoAccept.cs
@@ -5,14 +5,19 @@ using System.Linq;
 using FFXIVClientStructs.FFXIV.Client.UI;
 
 using Lumina.Excel.Sheets;
+using Lumina.Text.ReadOnly;
+
+using MasterOfPuppets.Ipc;
 
 namespace MasterOfPuppets;
 
 internal static unsafe partial class GameDialogManager {
-    private static string TextAcceptJoinParty =>
+    private static string? _lastPartyInviteDiagnosticKey;
+
+    private static ReadOnlySeString TextAcceptJoinParty =>
         DalamudApi.DataManager.GetExcelSheet<Addon>(DalamudApi.ClientState.ClientLanguage)
-            ?.GetRow(120).Text.ExtractText()
-        ?? "Join <string(lstr1)>'s party?";
+            ?.GetRow(120).Text
+        ?? default;
 
     private static string TextAcceptTeleport =>
             DalamudApi.DataManager.GetExcelSheet<Addon>(DalamudApi.ClientState.ClientLanguage)
@@ -27,23 +32,73 @@ internal static unsafe partial class GameDialogManager {
         bool acceptParty,
         bool acceptTeleport,
         bool acceptPartyOnlyFromCharacters = false,
-        IEnumerable<string>? partyInviteCharacterNames = null) {
+        IEnumerable<Character>? partyInviteCharacters = null,
+        IEnumerable<PeerCharacterInfo>? connectedPeers = null) {
         if (!acceptParty && !acceptTeleport) return;
-        if (!IsAddonVisible(AddonName.SelectYesno)) return;
+        if (!IsAddonVisible(AddonName.SelectYesno)) {
+            _lastPartyInviteDiagnosticKey = null;
+            return;
+        }
 
         var addon = (AddonSelectYesno*)GetAddonByName(AddonName.SelectYesno);
         if (addon == null || addon->PromptText == null) return;
 
-        var text = addon->PromptText->NodeText.ToString();
+        var rawText = addon->PromptText->NodeText.ToString();
+        var text = new ReadOnlySeStringSpan(addon->PromptText->NodeText.AsSpan()).ExtractText();
+        if (string.IsNullOrWhiteSpace(text))
+            text = rawText;
         if (string.IsNullOrEmpty(text)) return;
 
-        if (acceptParty && ContainsAllFragments(text, TextAcceptJoinParty)) {
-            if (!acceptPartyOnlyFromCharacters ||
-                PartyInvitePromptMatcher.IsInviterInCharacterList(text, partyInviteCharacterNames ?? Enumerable.Empty<string>()))
-                ClickYes();
-            return;
+        if (acceptParty) {
+            var partyDecision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+                text,
+                TextAcceptJoinParty,
+                partyInviteCharacters ?? Enumerable.Empty<Character>(),
+                connectedPeers ?? Enumerable.Empty<PeerCharacterInfo>());
+            var isPartyInvite = partyDecision.Parse.IsPartyInvite;
+            var shouldAccept = isPartyInvite && (!acceptPartyOnlyFromCharacters || partyDecision.ShouldAccept);
+            LogPartyInviteDiagnostic(rawText, text, partyDecision, acceptPartyOnlyFromCharacters, shouldAccept);
+
+            if (isPartyInvite) {
+                if (shouldAccept)
+                    ClickYes();
+                return;
+            }
         }
+
         if (acceptTeleport && ContainsAllFragments(text, TextAcceptTeleport)) { ClickYes(); return; }
+    }
+
+    private static void LogPartyInviteDiagnostic(
+        string rawText,
+        string text,
+        PartyInviteDecision decision,
+        bool onlyFromCharacters,
+        bool shouldAccept) {
+        var parse = decision.Parse;
+        var expression = parse.Expression;
+        var key = string.Join(
+            "\u001f",
+            rawText,
+            text,
+            expression.SourceText,
+            parse.InviterSegment,
+            parse.SheetExpressionAvailable,
+            parse.SheetExpressionReason,
+            decision.Reason,
+            onlyFromCharacters,
+            shouldAccept);
+        if (_lastPartyInviteDiagnosticKey == key)
+            return;
+
+        _lastPartyInviteDiagnosticKey = key;
+        DalamudApi.PluginLog.Verbose(
+            $"[AutoAcceptPartyInvite] rawText=\"{rawText}\" cleanedText=\"{text}\" addonRow=\"{expression.SourceText}\" " +
+            $"expression=\"prefix:{expression.Prefix}|suffix:{expression.Suffix}\" " +
+            $"sheetExpressionAvailable={parse.SheetExpressionAvailable} sheetExpressionReason=\"{parse.SheetExpressionReason}\" " +
+            $"extracted=\"{parse.InviterSegment}\" isPartyInvite={parse.IsPartyInvite} onlyFromCharacters={onlyFromCharacters} " +
+            $"connectedPeers={decision.ConnectedPeerCount} freshPeers={decision.FreshPeerCount} matchedPeer=\"{decision.MatchedPeer}\" " +
+            $"configMatch=\"{decision.ConfigMatch}\" accept={shouldAccept} reason=\"{decision.Reason}\"");
     }
 
     // Splits the extracted Addon row text (which has template vars stripped) into words ≥ 3 chars

--- a/MasterOfPuppets/Game/GameDialog/PartyInvitePromptMatcher.cs
+++ b/MasterOfPuppets/Game/GameDialog/PartyInvitePromptMatcher.cs
@@ -1,31 +1,30 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
-using Lumina.Excel.Sheets;
+using Lumina.Text.Payloads;
+using Lumina.Text.ReadOnly;
+
+using MasterOfPuppets.Ipc;
+
 namespace MasterOfPuppets;
 
 public static class PartyInvitePromptMatcher {
-    // TODO: replace by sheet string (locale-aware)
-    private static string TextPartyInvite =>
-        DalamudApi.DataManager.GetExcelSheet<Addon>(DalamudApi.ClientState.ClientLanguage)
-            ?.GetRow(120).Text.ExtractText()
-        ?? "Join <string(lstr1)>'s party?";
-    private const string PartyInvitePrefix = "Join ";
-    private const string PartyInviteSuffix = "'s party?";
+    private static readonly TimeSpan DefaultConnectedPeerMaxAge = TimeSpan.FromSeconds(5);
 
     public static bool ShouldAcceptPartyInvite(
         string promptText,
         bool onlyFromCharacters,
         IEnumerable<string> characterNames) {
-        if (!TryGetPartyInviteInviterSegment(promptText, out _))
+        if (!TryGetPartyInviteInviterSegment(promptText, string.Empty, out _))
             return false;
 
         return !onlyFromCharacters || IsInviterInCharacterList(promptText, characterNames);
     }
 
     public static bool IsInviterInCharacterList(string promptText, IEnumerable<string> characterNames) {
-        if (!TryGetPartyInviteInviterSegment(promptText, out var inviterSegment))
+        if (!TryGetPartyInviteInviterSegment(promptText, string.Empty, out var inviterSegment))
             return false;
 
         return characterNames
@@ -33,22 +32,250 @@ public static class PartyInvitePromptMatcher {
             .Any(name => MatchesCharacter(inviterSegment, name));
     }
 
-    public static bool TryGetPartyInviteInviterSegment(string promptText, out string inviterSegment) {
-        inviterSegment = string.Empty;
+    public static bool IsInviterInConnectedConfiguredCharacters(
+        string promptText,
+        IEnumerable<Character> configuredCharacters,
+        IEnumerable<PeerCharacterInfo> connectedPeers,
+        DateTime? now = null,
+        TimeSpan? maxPeerAge = null) {
+        return EvaluateConnectedConfiguredInvite(
+            promptText,
+            string.Empty,
+            configuredCharacters,
+            connectedPeers,
+            now,
+            maxPeerAge).ShouldAccept;
+    }
 
-        if (string.IsNullOrWhiteSpace(promptText))
+    public static bool TryGetPartyInviteInviterSegment(string promptText, string addonRowText, out string inviterSegment) {
+        var result = ParsePartyInvitePrompt(promptText, addonRowText);
+        inviterSegment = result.InviterSegment;
+        return result.IsPartyInvite;
+    }
+
+    public static PartyInviteDecision EvaluateConnectedConfiguredInvite(
+        string promptText,
+        string addonRowText,
+        IEnumerable<Character> configuredCharacters,
+        IEnumerable<PeerCharacterInfo> connectedPeers,
+        DateTime? now = null,
+        TimeSpan? maxPeerAge = null) {
+        return EvaluateConnectedConfiguredInvite(
+            ParsePartyInvitePrompt(promptText, addonRowText),
+            configuredCharacters,
+            connectedPeers,
+            now,
+            maxPeerAge);
+    }
+
+    internal static PartyInviteDecision EvaluateConnectedConfiguredInvite(
+        string promptText,
+        ReadOnlySeString addonRowText,
+        IEnumerable<Character> configuredCharacters,
+        IEnumerable<PeerCharacterInfo> connectedPeers,
+        DateTime? now = null,
+        TimeSpan? maxPeerAge = null) {
+        return EvaluateConnectedConfiguredInvite(
+            ParsePartyInvitePrompt(promptText, addonRowText),
+            configuredCharacters,
+            connectedPeers,
+            now,
+            maxPeerAge);
+    }
+
+    private static PartyInviteDecision EvaluateConnectedConfiguredInvite(
+        PartyInvitePromptParseResult parse,
+        IEnumerable<Character> configuredCharacters,
+        IEnumerable<PeerCharacterInfo> connectedPeers,
+        DateTime? now = null,
+        TimeSpan? maxPeerAge = null) {
+        var currentTime = now ?? DateTime.UtcNow;
+        var peerMaxAge = maxPeerAge ?? DefaultConnectedPeerMaxAge;
+        var peers = connectedPeers.ToList();
+        var freshPeers = peers
+            .Where(peer => IsFreshPeer(peer, currentTime, peerMaxAge))
+            .ToList();
+        if (!parse.IsPartyInvite)
+            return new PartyInviteDecision(
+                ShouldAccept: false,
+                Parse: parse,
+                ConnectedPeerCount: peers.Count,
+                FreshPeerCount: freshPeers.Count,
+                MatchedPeer: string.Empty,
+                ConfigMatch: string.Empty,
+                Reason: "prompt did not match party invite expression");
+
+        var configured = configuredCharacters
+            .Where(character => character != null)
+            .ToList();
+
+        foreach (var peer in freshPeers) {
+            if (!MatchesPeer(parse.InviterSegment, peer, out var peerMatchDetails))
+                continue;
+
+            if (IsPeerConfigured(peer, configured, out var configMatchDetails))
+                return new PartyInviteDecision(
+                    ShouldAccept: true,
+                    Parse: parse,
+                    ConnectedPeerCount: peers.Count,
+                    FreshPeerCount: freshPeers.Count,
+                    MatchedPeer: FormatPeer(peer),
+                    ConfigMatch: configMatchDetails,
+                    Reason: $"matched peer ({peerMatchDetails}) and configured character ({configMatchDetails})");
+
+            return new PartyInviteDecision(
+                ShouldAccept: false,
+                Parse: parse,
+                ConnectedPeerCount: peers.Count,
+                FreshPeerCount: freshPeers.Count,
+                MatchedPeer: FormatPeer(peer),
+                ConfigMatch: string.Empty,
+                Reason: $"matched peer ({peerMatchDetails}) but peer is not configured");
+        }
+
+        return new PartyInviteDecision(
+            ShouldAccept: false,
+            Parse: parse,
+            ConnectedPeerCount: peers.Count,
+            FreshPeerCount: freshPeers.Count,
+            MatchedPeer: string.Empty,
+            ConfigMatch: string.Empty,
+            Reason: "no fresh connected peer matched inviter segment");
+    }
+
+    public static PartyInvitePromptParseResult ParsePartyInvitePrompt(string promptText, string addonRowText) {
+        if (!TryBuildExtractionExpression(addonRowText, out var expression, out var expressionReason))
+            return PartyInvitePromptParseResult.NotMatched(
+                promptText?.Trim() ?? string.Empty,
+                addonRowText?.Trim() ?? string.Empty,
+                expressionReason);
+
+        return ParsePartyInvitePrompt(promptText, expression);
+    }
+
+    internal static PartyInvitePromptParseResult ParsePartyInvitePrompt(string promptText, ReadOnlySeString addonRowText) {
+        if (!TryBuildExtractionExpression(addonRowText, out var expression, out var expressionReason))
+            return PartyInvitePromptParseResult.NotMatched(
+                promptText?.Trim() ?? string.Empty,
+                addonRowText.IsEmpty ? string.Empty : addonRowText.ToMacroString(),
+                expressionReason);
+
+        return ParsePartyInvitePrompt(promptText, expression);
+    }
+
+    private static PartyInvitePromptParseResult ParsePartyInvitePrompt(
+        string promptText,
+        PartyInviteExtractionExpression expression) {
+        var text = promptText?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(text))
+            return PartyInvitePromptParseResult.NotMatched(text, expression, "prompt text is empty");
+
+        if (!text.StartsWith(expression.Prefix, StringComparison.OrdinalIgnoreCase))
+            return PartyInvitePromptParseResult.NotMatched(text, expression, "prompt does not start with expression prefix");
+
+        var end = string.IsNullOrEmpty(expression.Suffix)
+            ? text.Length
+            : text.IndexOf(expression.Suffix, expression.Prefix.Length, StringComparison.OrdinalIgnoreCase);
+        if (end <= expression.Prefix.Length)
+            return PartyInvitePromptParseResult.NotMatched(text, expression, "expression suffix was not found after prefix");
+
+        var inviterSegment = text[expression.Prefix.Length..end].Trim();
+        if (string.IsNullOrWhiteSpace(inviterSegment))
+            return PartyInvitePromptParseResult.NotMatched(text, expression, "inviter segment is empty");
+
+        return PartyInvitePromptParseResult.Matched(text, expression, inviterSegment);
+    }
+
+    public static bool TryBuildExtractionExpression(
+        string addonRowText,
+        out PartyInviteExtractionExpression expression,
+        out string reason) {
+        expression = new PartyInviteExtractionExpression(addonRowText?.Trim() ?? string.Empty, string.Empty, string.Empty);
+        reason = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(addonRowText)) {
+            reason = "party invite sheet expression unavailable";
             return false;
+        }
 
-        var text = promptText.Trim();
-        if (!text.StartsWith(PartyInvitePrefix, StringComparison.OrdinalIgnoreCase))
+        var text = addonRowText.Trim();
+        var placeholderStart = text.IndexOf("<string", StringComparison.OrdinalIgnoreCase);
+        if (placeholderStart < 0) {
+            reason = "party invite sheet expression has no string payload";
             return false;
+        }
 
-        var end = text.IndexOf(PartyInviteSuffix, PartyInvitePrefix.Length, StringComparison.OrdinalIgnoreCase);
-        if (end <= PartyInvitePrefix.Length)
+        var placeholderEnd = text.IndexOf('>', placeholderStart);
+        if (placeholderEnd <= placeholderStart) {
+            reason = "party invite sheet expression has unterminated string payload";
             return false;
+        }
 
-        inviterSegment = text[PartyInvitePrefix.Length..end].Trim();
-        return !string.IsNullOrWhiteSpace(inviterSegment);
+        var prefix = text[..placeholderStart];
+        var suffix = text[(placeholderEnd + 1)..];
+        if (string.IsNullOrEmpty(prefix) && string.IsNullOrEmpty(suffix)) {
+            reason = "party invite sheet expression has no static text";
+            return false;
+        }
+
+        expression = new PartyInviteExtractionExpression(text, prefix, suffix);
+        reason = "party invite sheet expression parsed";
+        return true;
+    }
+
+    internal static bool TryBuildExtractionExpression(
+        ReadOnlySeString addonRowText,
+        out PartyInviteExtractionExpression expression,
+        out string reason) {
+        var sourceText = addonRowText.IsEmpty ? string.Empty : addonRowText.ToMacroString();
+        expression = new PartyInviteExtractionExpression(sourceText, string.Empty, string.Empty);
+        reason = string.Empty;
+
+        if (addonRowText.IsEmpty) {
+            reason = "party invite sheet expression unavailable";
+            return false;
+        }
+
+        var prefix = new StringBuilder();
+        var suffix = new StringBuilder();
+        var foundStringPayload = false;
+        foreach (var payload in addonRowText) {
+            if (payload.Type == ReadOnlySePayloadType.Text) {
+                (foundStringPayload ? suffix : prefix).Append(payload.ToString());
+                continue;
+            }
+
+            if (payload.Type != ReadOnlySePayloadType.Macro) {
+                reason = $"party invite sheet expression has unsupported payload type {payload.Type}";
+                return false;
+            }
+
+            if (payload.MacroCode != MacroCode.String) {
+                reason = $"party invite sheet expression has unsupported macro payload {payload.MacroCode}";
+                return false;
+            }
+
+            if (foundStringPayload) {
+                reason = "party invite sheet expression has multiple string payloads";
+                return false;
+            }
+
+            foundStringPayload = true;
+        }
+
+        if (!foundStringPayload) {
+            reason = "party invite sheet expression has no string payload";
+            return false;
+        }
+
+        if (prefix.Length == 0 && suffix.Length == 0) {
+            reason = "party invite sheet expression has no static text";
+            return false;
+        }
+
+        expression = new PartyInviteExtractionExpression(sourceText, prefix.ToString(), suffix.ToString());
+        reason = "party invite sheet expression parsed";
+        return true;
     }
 
     private static bool MatchesCharacter(string inviterSegment, string savedCharacterName) {
@@ -65,6 +292,74 @@ public static class PartyInvitePromptMatcher {
         return inviterSegment.Equals(name, StringComparison.OrdinalIgnoreCase);
     }
 
+    private static bool MatchesPeer(string inviterSegment, PeerCharacterInfo peer, out string details) {
+        details = string.Empty;
+        if (string.IsNullOrWhiteSpace(peer.CharacterName))
+            return false;
+
+        if (!inviterSegment.StartsWith(peer.CharacterName, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var remainder = inviterSegment[peer.CharacterName.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(remainder)) {
+            details = "name-only prompt";
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(peer.HomeWorld) &&
+            ContainsWorldName(remainder, peer.HomeWorld)) {
+            details = "home world in prompt";
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(peer.CurrentWorld) &&
+            ContainsWorldName(remainder, peer.CurrentWorld)) {
+            details = "current world in prompt";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsPeerConfigured(PeerCharacterInfo peer, IReadOnlyList<Character> configuredCharacters, out string details) {
+        details = string.Empty;
+        foreach (var character in configuredCharacters) {
+            if (character.Cid != 0 && character.Cid == peer.ContentId) {
+                details = $"cid:{character.Cid}";
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(character.Name))
+                continue;
+
+            var (configuredName, configuredWorld) = SplitCharacterName(character.Name);
+            if (!configuredName.Equals(peer.CharacterName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (string.IsNullOrWhiteSpace(configuredWorld)) {
+                details = $"name:{character.Name}";
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(peer.CurrentWorld) &&
+                configuredWorld.Equals(peer.CurrentWorld, StringComparison.OrdinalIgnoreCase)) {
+                details = $"name-current-world:{character.Name}";
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(peer.HomeWorld) &&
+                configuredWorld.Equals(peer.HomeWorld, StringComparison.OrdinalIgnoreCase)) {
+                details = $"name-home-world:{character.Name}";
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsFreshPeer(PeerCharacterInfo peer, DateTime now, TimeSpan maxAge) =>
+        peer.LastSeen != default && now - peer.LastSeen <= maxAge;
+
     private static bool MatchesNameAndWorld(string inviterSegment, string name, string world) {
         if (inviterSegment.Length <= name.Length)
             return false;
@@ -80,6 +375,23 @@ public static class PartyInvitePromptMatcher {
         return remainder.Equals(world, StringComparison.OrdinalIgnoreCase);
     }
 
+    private static bool ContainsWorldName(string value, string world) {
+        var normalizedValue = NormalizeNameWorldSegment(value);
+        var normalizedWorld = NormalizeNameWorldSegment(world);
+        return normalizedValue.Contains(normalizedWorld, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeNameWorldSegment(string value) {
+        var chars = value
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToLowerInvariant)
+            .ToArray();
+        return new string(chars);
+    }
+
+    private static string FormatPeer(PeerCharacterInfo peer) =>
+        $"{peer.CharacterName}@{peer.HomeWorld}/{peer.CurrentWorld} cid={peer.ContentId}";
+
     private static (string Name, string World) SplitCharacterName(string characterName) {
         var trimmed = characterName.Trim();
         var separatorIndex = trimmed.LastIndexOf('@');
@@ -88,4 +400,55 @@ public static class PartyInvitePromptMatcher {
 
         return (trimmed[..separatorIndex].Trim(), trimmed[(separatorIndex + 1)..].Trim());
     }
+}
+
+public sealed record PartyInviteExtractionExpression(
+    string SourceText,
+    string Prefix,
+    string Suffix);
+
+public sealed record PartyInvitePromptParseResult(
+    bool IsPartyInvite,
+    string PromptText,
+    PartyInviteExtractionExpression Expression,
+    string InviterSegment,
+    bool SheetExpressionAvailable,
+    string SheetExpressionReason,
+    string Reason) {
+    public static PartyInvitePromptParseResult Matched(
+        string promptText,
+        PartyInviteExtractionExpression expression,
+        string inviterSegment) =>
+        new(true, promptText, expression, inviterSegment, true, "party invite sheet expression parsed", "matched");
+
+    public static PartyInvitePromptParseResult NotMatched(
+        string promptText,
+        PartyInviteExtractionExpression expression,
+        string reason) =>
+        new(false, promptText, expression, string.Empty, true, "party invite sheet expression parsed", reason);
+
+    public static PartyInvitePromptParseResult NotMatched(
+        string promptText,
+        string addonRowText,
+        string sheetExpressionReason) =>
+        new(
+            false,
+            promptText,
+            new PartyInviteExtractionExpression(addonRowText, string.Empty, string.Empty),
+            string.Empty,
+            false,
+            sheetExpressionReason,
+            sheetExpressionReason);
+}
+
+public sealed record PartyInviteDecision(
+    bool ShouldAccept,
+    PartyInvitePromptParseResult Parse,
+    int ConnectedPeerCount,
+    int FreshPeerCount,
+    string MatchedPeer,
+    string ConfigMatch,
+    string Reason) {
+    public static PartyInviteDecision Rejected(PartyInvitePromptParseResult parse, string reason) =>
+        new(false, parse, 0, 0, string.Empty, string.Empty, reason);
 }

--- a/MasterOfPuppets/Game/Login/AutoLoginManager.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginManager.cs
@@ -28,16 +28,16 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
     private readonly Plugin _plugin;
     private readonly Stopwatch _stateTimer = new();
     private LoginState _state = LoginState.Idle;
-    private int _worldIndex;
     private int _stateDelayMs;
     private List<AutoLoginCandidate> _candidates = [];
-    private List<string> _worldQueue = [];
+    private AutoLoginTarget? _target;
     private string _pendingCharacterName = string.Empty;
     private int _pendingCharacterIndex = -1;
     private bool _hasPendingCharacterSelection;
     private IActiveNotification? _cancelNotification;
 
     private const int StateTimeoutMs = 30_000;
+    private const int ConfirmingLoginTimeoutMs = 120_000;
     private const int CharacterSelectDelayMinMs = 2_000;
     private const int CharacterSelectDelayMaxMs = 4_000;
 
@@ -63,8 +63,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             return;
         }
 
-        _worldIndex = 0;
-        _worldQueue = [];
+        _target = null;
         ClearPendingCharacterSelection();
         ShowCancelNotification();
         SetState(LoginState.WaitingTitleMenu);
@@ -82,7 +81,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         _stateDelayMs = 0;
         _stateTimer.Reset();
         _candidates = [];
-        _worldQueue = [];
+        _target = null;
         ClearPendingCharacterSelection();
         if (dismissNotification)
             DismissCancelNotification();
@@ -101,8 +100,8 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
                 return;
             }
 
-            if (_stateTimer.ElapsedMilliseconds > StateTimeoutMs) {
-                DalamudApi.PluginLog.Warning($"[AutoLogin] Timed out in state {_state}.");
+            if (_stateTimer.ElapsedMilliseconds > GetStateTimeoutMs()) {
+                LogTimeout();
                 Stop();
                 return;
             }
@@ -139,17 +138,36 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         if (!GameDialogManager.IsAddonOpen("_CharaSelectWorldServer"))
             return;
 
-        if (_worldQueue.Count == 0) {
-            var visibleWorlds = WorldNames;
-            if (visibleWorlds.Count == 0)
-                return;
+        var visibleWorlds = WorldNames;
+        if (visibleWorlds.Count == 0)
+            return;
 
-            _worldQueue = AutoLoginPlanner.BuildWorldQueue(_candidates, ReadLobbyEntries(), visibleWorlds);
-            DalamudApi.PluginLog.Information(
-                $"[AutoLogin] World scan queue: {(_worldQueue.Count == 0 ? "<empty>" : string.Join(", ", _worldQueue))}.");
+        var lobbyEntries = ReadLobbyEntries();
+        if (lobbyEntries.Count == 0) {
+            DalamudApi.PluginLog.Warning("[AutoLogin] Lobby character data was unavailable.");
+            Stop();
+            return;
         }
 
-        SelectNextWorldCandidate();
+        _target = AutoLoginPlanner.ResolveTarget(_candidates, lobbyEntries);
+        if (_target == null) {
+            DalamudApi.PluginLog.Warning("[AutoLogin] Could not resolve an enabled auto-login character from lobby data.");
+            Stop();
+            return;
+        }
+
+        DalamudApi.PluginLog.Information(
+            $"[AutoLogin] Resolved auto-login target: {_target.Value.CharacterName} on {_target.Value.WorldName}.");
+        if (!SelectWorld(_target.Value.WorldName, out var worldIndex)) {
+            DalamudApi.PluginLog.Warning(
+                $"[AutoLogin] Resolved world '{_target.Value.WorldName}' was not visible in the world selector.");
+            Stop();
+            return;
+        }
+
+        DalamudApi.PluginLog.Information(
+            $"[AutoLogin] Checking resolved character {_target.Value.CharacterName} on {_target.Value.WorldName} at index {worldIndex}.");
+        SetState(LoginState.WaitingCharacterList);
     }
 
     private void HandleWaitingCharacterList() {
@@ -164,14 +182,20 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             _pendingCharacterIndex < 0 ||
             _pendingCharacterIndex >= visibleCharacters.Count ||
             !visibleCharacters[_pendingCharacterIndex].Equals(_pendingCharacterName, StringComparison.InvariantCultureIgnoreCase)) {
+            if (_target == null) {
+                DalamudApi.PluginLog.Warning("[AutoLogin] Resolved auto-login target was cleared before character selection.");
+                Stop();
+                return;
+            }
+
             if (!AutoLoginPlanner.TryFindVisibleCandidate(
-                    _candidates,
+                    [new AutoLoginCandidate(0, _target.Value.CharacterName)],
                     visibleCharacters,
                     out _pendingCharacterName,
                     out _pendingCharacterIndex)) {
-                DalamudApi.PluginLog.Information(
-                    $"[AutoLogin] No checked character visible on this world. Checked: {string.Join(", ", _candidates.Select(c => c.Name))}. Visible: {string.Join(", ", visibleCharacters)}.");
-                SelectNextWorldCandidate();
+                DalamudApi.PluginLog.Warning(
+                    $"[AutoLogin] Resolved character '{_target.Value.CharacterName}' was not visible after selecting {_target.Value.WorldName}.");
+                Stop();
                 return;
             }
 
@@ -209,22 +233,18 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             SendTitleAction(GameDialogManager.AddonName.SelectYesno, 3, 0);
     }
 
-    private void SelectNextWorldCandidate() {
-        ClearPendingCharacterSelection();
-        while (_worldIndex < _worldQueue.Count) {
-            var world = _worldQueue[_worldIndex++];
-            if (!SelectWorld(world, out var worldIndex)) {
-                DalamudApi.PluginLog.Debug($"[AutoLogin] World '{world}' not available in current list.");
-                continue;
-            }
+    private int GetStateTimeoutMs() => _state == LoginState.ConfirmingLogin
+        ? ConfirmingLoginTimeoutMs
+        : StateTimeoutMs;
 
-            DalamudApi.PluginLog.Information($"[AutoLogin] Checking checked characters on {world} at index {worldIndex}.");
-            SetState(LoginState.WaitingCharacterList);
+    private void LogTimeout() {
+        if (_state == LoginState.ConfirmingLogin) {
+            DalamudApi.PluginLog.Information(
+                $"[AutoLogin] Login confirmation still pending after {ConfirmingLoginTimeoutMs}ms; stopping auto-login watcher after character selection was submitted.");
             return;
         }
 
-        DalamudApi.PluginLog.Warning("[AutoLogin] None of the configured characters were found on the current data center.");
-        Stop();
+        DalamudApi.PluginLog.Warning($"[AutoLogin] Timed out in state {_state}.");
     }
 
     private List<AutoLoginCandidate> GetLoginCandidates() {

--- a/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
@@ -33,30 +33,21 @@ public readonly record struct AutoLoginLobbyEntry(
     string RawJson,
     string ClientSelectWorldName);
 
-public static class AutoLoginPlanner {
-    public static List<string> BuildWorldQueue(
-        IReadOnlyList<AutoLoginCandidate> candidates,
-        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
-        IReadOnlyList<string> visibleWorlds) {
-        var worldQueue = new List<string>();
-        var visibleWorldSet = visibleWorlds.ToHashSet(StringComparer.InvariantCultureIgnoreCase);
+public readonly record struct AutoLoginTarget(string CharacterName, string WorldName);
 
+public static class AutoLoginPlanner {
+    public static AutoLoginTarget? ResolveTarget(
+        IReadOnlyList<AutoLoginCandidate> candidates,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) {
         foreach (var candidate in candidates) {
             var entry = FindCandidateEntry(candidate, lobbyEntries);
-            if (entry == null)
+            if (entry == null || string.IsNullOrWhiteSpace(entry.Value.CurrentWorldName))
                 continue;
 
-            AddWorld(worldQueue, visibleWorldSet, entry.Value.CurrentWorldName);
+            return new AutoLoginTarget(entry.Value.Name, entry.Value.CurrentWorldName);
         }
 
-        foreach (var entry in lobbyEntries)
-            AddWorld(worldQueue, visibleWorldSet, entry.CurrentWorldName);
-
-        if (lobbyEntries.Count == 0)
-            foreach (var world in visibleWorlds)
-                AddWorld(worldQueue, visibleWorldSet, world);
-
-        return worldQueue;
+        return null;
     }
 
     public static bool TryFindVisibleCandidate(
@@ -94,13 +85,5 @@ public static class AutoLoginPlanner {
         }
 
         return null;
-    }
-
-    private static void AddWorld(List<string> worldQueue, HashSet<string> visibleWorldSet, string worldName) {
-        if (string.IsNullOrWhiteSpace(worldName) || !visibleWorldSet.Contains(worldName))
-            return;
-
-        if (!worldQueue.Contains(worldName, StringComparer.InvariantCultureIgnoreCase))
-            worldQueue.Add(worldName);
     }
 }

--- a/MasterOfPuppets/Game/Movement/MovementManager.cs
+++ b/MasterOfPuppets/Game/Movement/MovementManager.cs
@@ -173,6 +173,10 @@ public class MovementManager : IDisposable {
     public void StopMove() {
         DalamudApi.Framework.RunOnFrameworkThread(() => {
             _stuckRetryCount = 0;
+            if (_pendingTask is { IsCompleted: true })
+                _pendingTask.Dispose();
+            _pendingTask = null;
+            _pendingFacing = null;
             GameFunctions.StopFollow();
             _follow.ForceStop();
         });

--- a/MasterOfPuppets/Game/Movement/SimpleInputMovement.cs
+++ b/MasterOfPuppets/Game/Movement/SimpleInputMovement.cs
@@ -90,11 +90,12 @@ public unsafe class SimpleInputMovement : IDisposable {
     }
 
     public void Dispose() {
-        _cts?.Cancel();
-        _cts?.Dispose();
+        var cts = _cts;
         _cts = null;
+        cts?.Cancel();
+        cts?.Dispose();
 
-        _direction = MovementDirection.None;
+        Direction = MovementDirection.None;
 
         _playerMoveHook?.Disable();
         _playerMoveHook?.Dispose();
@@ -112,16 +113,23 @@ public unsafe class SimpleInputMovement : IDisposable {
     }
 
     public void StopMove() {
-        CancelActiveMove(callNativeStop: true);
+        if (DalamudApi.Framework.IsInFrameworkUpdateThread) {
+            CancelActiveMove(callNativeStop: true);
+            return;
+        }
+
+        _ = DalamudApi.Framework.RunOnFrameworkThread(() => CancelActiveMove(callNativeStop: true));
     }
 
     private void CancelActiveMove(bool callNativeStop) {
-        _cts?.Cancel();
-        _cts?.Dispose();
-        _cts = null;
+        var cts = _cts;
+        if (cts != null) {
+            cts.Cancel();
+            if (ReferenceEquals(_cts, cts))
+                _cts = null;
+        }
 
-        _direction = MovementDirection.None;
-        _playerMoveHook?.Disable();
+        Direction = MovementDirection.None;
         IsWalking = false;
 
         if (!callNativeStop)
@@ -146,17 +154,34 @@ public unsafe class SimpleInputMovement : IDisposable {
         Vector3 destination,
         float precision = 0.3f,
         float? faceDirection = null,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Precise) {
+        MovementArrivalMode arrivalMode = MovementArrivalMode.Precise,
+        bool stopOnStuck = false,
+        float stuckTolerance = 0.05f,
+        int stuckTimeoutMs = 500) {
+        if (!DalamudApi.Framework.IsInFrameworkUpdateThread) {
+            _ = DalamudApi.Framework.RunOnFrameworkThread(() => MoveTo(
+                destination,
+                precision,
+                faceDirection,
+                arrivalMode,
+                stopOnStuck,
+                stuckTolerance,
+                stuckTimeoutMs));
+            return null;
+        }
+
         // Refuse to start while the player is performing - movement is blocked
         // by the game anyway, so there is nothing useful we could do.
         if (DalamudApi.Condition[ConditionFlag.Performing])
             return null;
 
-        // Cancel any previous move before starting a new one.
-        CancelActiveMove(callNativeStop: false);
+        // Cancel any previous move before starting a new one. Use native stop as
+        // well so continuous moves cannot leave latched input behind.
+        CancelActiveMove(callNativeStop: true);
 
         var cts = new CancellationTokenSource();
         _cts = cts;
+        var stuckTracker = stopOnStuck ? new SimpleMovementProgressTracker() : null;
 
         // Snapshot current control settings so we can restore them on exit,
         // regardless of whether we finish, are cancelled, or Performing fires.
@@ -181,6 +206,12 @@ public unsafe class SimpleInputMovement : IDisposable {
                 }
 
                 var distance = player.Position.Distance2D(destination);
+                if (stuckTracker != null && stuckTracker.Update(player.Position, Environment.TickCount64, stuckTolerance, stuckTimeoutMs)) {
+                    DalamudApi.PluginLog.Warning(
+                        $"[SimpleInputMovement] Stuck for {stuckTimeoutMs}ms near {player.Position}; destination={destination}; stopping.");
+                    CancelActiveMove(callNativeStop: true);
+                    return;
+                }
 
                 // Re-face target every frame in case the player drifts.
                 GameFunctions.FaceDirection(destination);
@@ -192,29 +223,36 @@ public unsafe class SimpleInputMovement : IDisposable {
                 IsWalking = GetArrivalState(distance, precision, arrivalMode) == ArrivalMovementState.Walk;
             },
             callback: () => {
-                // Restore control settings regardless of how the loop ended.
-                DalamudApi.GameConfig.UiControl.Set("MoveMode", savedMoveMode);
-                DalamudApi.GameConfig.UiConfig.Set("PadMode", savedPadMode);
+                var newerMoveStarted = _cts != null && !ReferenceEquals(_cts, cts);
+                if (!newerMoveStarted) {
+                    // Restore control settings unless this callback belongs to
+                    // an older move that was replaced by a newer one.
+                    DalamudApi.GameConfig.UiControl.Set("MoveMode", savedMoveMode);
+                    DalamudApi.GameConfig.UiConfig.Set("PadMode", savedPadMode);
 
-                Direction = MovementDirection.None;
-                if (arrivalMode == MovementArrivalMode.Precise) {
-                    try {
-                        MoveStopNative();
-                    } catch {
-                        // ignored
+                    Direction = MovementDirection.None;
+                    if (arrivalMode == MovementArrivalMode.Precise) {
+                        try {
+                            MoveStopNative();
+                        } catch {
+                            // ignored
+                        }
+                    }
+
+                    IsWalking = savedIsWalking;
+
+                    // Apply endpoint rotation only on clean arrival (not on cancel
+                    // or Performing - the player may be mid-performance already).
+                    if (faceDirection is float rot
+                        && !cts.IsCancellationRequested
+                        && !DalamudApi.Condition[ConditionFlag.Performing]) {
+                        GameFunctions.FaceDirectionDeferred(rot.Radians());
                     }
                 }
-                IsWalking = savedIsWalking;
 
-                // Apply endpoint rotation only on clean arrival (not on cancel
-                // or Performing - the player may be mid-performance already).
-                if (faceDirection is float rot
-                    && !cts.IsCancellationRequested
-                    && !DalamudApi.Condition[ConditionFlag.Performing]) {
-                    GameFunctions.FaceDirectionDeferred(rot.Radians());
-                }
-
-                _cts = null;
+                if (ReferenceEquals(_cts, cts))
+                    _cts = null;
+                cts.Dispose();
             },
             stopWhen: () => {
                 // var player = DalamudApi.ObjectTable.LocalPlayer;
@@ -264,6 +302,35 @@ public enum ArrivalMovementState {
     Run,
     Walk,
     Stop,
+}
+
+public sealed class SimpleMovementProgressTracker {
+    private Vector3 _lastSignificantPosition;
+    private long _lastProgressMs;
+    private bool _hasPosition;
+
+    public void Reset() {
+        _lastSignificantPosition = default;
+        _lastProgressMs = 0;
+        _hasPosition = false;
+    }
+
+    public bool Update(Vector3 position, long nowMs, float movementTolerance, int timeoutMs) {
+        if (!_hasPosition) {
+            _lastSignificantPosition = position;
+            _lastProgressMs = nowMs;
+            _hasPosition = true;
+            return false;
+        }
+
+        if (Vector3.Distance(position, _lastSignificantPosition) > Math.Max(0, movementTolerance)) {
+            _lastSignificantPosition = position;
+            _lastProgressMs = nowMs;
+            return false;
+        }
+
+        return nowMs - _lastProgressMs >= Math.Max(1, timeoutMs);
+    }
 }
 
 public enum MovementDirection : int {

--- a/MasterOfPuppets/Ipc/IpcProvider.CharacterData.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.CharacterData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -16,6 +17,9 @@ public record PeerCharacterInfo(
 );
 
 internal partial class IpcProvider {
+    private static readonly TimeSpan CharacterDataBroadcastInterval = TimeSpan.FromSeconds(1);
+    public static readonly TimeSpan PeerCharacterDataMaxAge = TimeSpan.FromSeconds(5);
+    private DateTime _nextCharacterDataBroadcast = DateTime.MinValue;
 
     /// <summary>
     /// Character info received from each peer. Key = ContentId.
@@ -30,6 +34,26 @@ internal partial class IpcProvider {
         BroadCast(IpcMessage.Create(IpcMessageType.RequestCharacterData).Serialize(), includeSelf: true);
     }
 
+    public void UpdateCharacterDataHeartbeat() {
+        var now = DateTime.UtcNow;
+        PruneStaleCharacterData(now);
+
+        if (now < _nextCharacterDataBroadcast)
+            return;
+
+        _nextCharacterDataBroadcast = now + CharacterDataBroadcastInterval;
+        BroadcastCharacterData(IpcMessageType.CharacterData);
+    }
+
+    public IReadOnlyList<PeerCharacterInfo> GetFreshPeerCharacterData() {
+        var now = DateTime.UtcNow;
+        PruneStaleCharacterData(now);
+        return PeerCharacterData.Values
+            .Where(peer => IsFreshPeer(peer, now))
+            .OrderBy(peer => peer.ContentId)
+            .ToList();
+    }
+
     [IpcHandle(IpcMessageType.RequestCharacterData)]
     private void HandleRequestCharacterData(IpcMessage message) {
         DalamudApi.Framework.RunOnFrameworkThread(() => BroadcastCharacterData(IpcMessageType.CharacterData));
@@ -39,6 +63,16 @@ internal partial class IpcProvider {
     private void HandleCharacterData(IpcMessage message) {
         PeerCharacterData[message.BroadcasterId] = ParseCharacterInfo(message) with { LastSeen = DateTime.UtcNow };
     }
+
+    private void PruneStaleCharacterData(DateTime now) {
+        foreach (var pair in PeerCharacterData) {
+            if (!IsFreshPeer(pair.Value, now))
+                PeerCharacterData.TryRemove(pair.Key, out _);
+        }
+    }
+
+    private static bool IsFreshPeer(PeerCharacterInfo peer, DateTime now) =>
+        peer.LastSeen != default && now - peer.LastSeen <= PeerCharacterDataMaxAge;
 
     internal void BroadcastCharacterData(IpcMessageType type) {
         if (!DalamudApi.PlayerState.IsLoaded) return;

--- a/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
@@ -89,7 +89,13 @@ internal partial class IpcProvider {
         // DalamudApi.PluginLog.Warning($"[ExecuteFormation] anchorPos: {anchorPos} worldPos: {worldPos} faceDirection: {facingRad}");
 
         // Plugin.MovementManager.MoveTo(worldPos, facingRad.Radians());
-        Plugin.SimpleInputMovement.MoveTo(worldPos, precision: Plugin.Config.FormationMovePrecision, faceDirection: facingRad);
+        Plugin.SimpleInputMovement.MoveTo(
+            worldPos,
+            precision: Plugin.Config.FormationMovePrecision,
+            faceDirection: facingRad,
+            stopOnStuck: Plugin.Config.StopOnStuck,
+            stuckTolerance: Plugin.Config.StuckTolerance,
+            stuckTimeoutMs: Plugin.Config.StuckTimeoutMs);
 
         // Member faces the same direction as the anchor (north offset = 0)
         // Plugin.MovementManager.MoveTo(worldPos, anchorRot.Radians());
@@ -100,15 +106,17 @@ internal partial class IpcProvider {
         bool reverse = false,
         int step = 1,
         int sequenceIndex = 0,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous) =>
-        DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationMoveOnFrameworkThread(name, reverse, step, sequenceIndex, arrivalMode));
+        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
+        FormationMoveAnchorMode anchorMode = FormationMoveAnchorMode.Self) =>
+        DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationMoveOnFrameworkThread(name, reverse, step, sequenceIndex, arrivalMode, anchorMode));
 
     private void ExecuteFormationMoveOnFrameworkThread(
         string name,
         bool reverse = false,
         int step = 1,
         int sequenceIndex = 0,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous) {
+        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
+        FormationMoveAnchorMode anchorMode = FormationMoveAnchorMode.Self) {
         var player = DalamudApi.ObjectTable.LocalPlayer;
         if (player == null) return;
 
@@ -128,19 +136,21 @@ internal partial class IpcProvider {
             return;
         }
 
-        var anchorPos = player.Position;
-        var anchorRot = player.Rotation;
+        if (!TryGetFormationAnchor(anchorMode == FormationMoveAnchorMode.Target, issuerCid, out var anchorPos, out var anchorRot, out var anchorCid))
+            return;
+
         BroadCast(IpcMessage.Create(IpcMessageType.ExecuteFormationMove,
             name,
             anchorPos.X.ToString("G", CultureInfo.InvariantCulture),
             anchorPos.Y.ToString("G", CultureInfo.InvariantCulture),
             anchorPos.Z.ToString("G", CultureInfo.InvariantCulture),
             anchorRot.ToString("G", CultureInfo.InvariantCulture),
-            issuerCid.ToString(CultureInfo.InvariantCulture),
+            anchorCid.ToString(CultureInfo.InvariantCulture),
             reverse ? "1" : "0",
             Math.Max(1, step).ToString(CultureInfo.InvariantCulture),
             sequenceIndex.ToString(CultureInfo.InvariantCulture),
-            arrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous").Serialize(), includeSelf: true);
+            arrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous",
+            anchorMode == FormationMoveAnchorMode.Target ? "target" : "self").Serialize(), includeSelf: true);
     }
 
     [IpcHandle(IpcMessageType.ExecuteFormationMove)]
@@ -162,7 +172,6 @@ internal partial class IpcProvider {
         var arrivalMode = message.StringData.Length >= 10 && message.StringData[9].Equals("precise", StringComparison.OrdinalIgnoreCase)
             ? MovementArrivalMode.Precise
             : MovementArrivalMode.Continuous;
-
         var formation = Plugin.Config.Formations.FirstOrDefault(f =>
             string.Equals(f.Name, name, StringComparison.OrdinalIgnoreCase));
         if (formation == null) {
@@ -198,7 +207,10 @@ internal partial class IpcProvider {
             move.Value.Position,
             precision: Plugin.Config.FormationMovePrecision,
             faceDirection: move.Value.Rotation,
-            arrivalMode: arrivalMode);
+            arrivalMode: arrivalMode,
+            stopOnStuck: Plugin.Config.StopOnStuck,
+            stuckTolerance: Plugin.Config.StuckTolerance,
+            stuckTimeoutMs: Plugin.Config.StuckTimeoutMs);
     }
 
     private FormationPoint? GetAssignedPoint(Formation formation, ulong playerCid) =>

--- a/MasterOfPuppets/Ipc/IpcProvider.Movement.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.Movement.cs
@@ -37,12 +37,12 @@ internal partial class IpcProvider {
     }
 
     public void StopMovement() {
-        BroadCast(IpcMessage.Create(IpcMessageType.StopMovement).Serialize(), includeSelf: true);
+        Plugin.StopAllMovementLocal();
+        BroadCast(IpcMessage.Create(IpcMessageType.StopMovement).Serialize(), includeSelf: false);
     }
 
     [IpcHandle(IpcMessageType.StopMovement)]
     private void HandleStopMovement(IpcMessage message) {
-        Plugin.SimpleInputMovement.StopMove();
-        Plugin.MovementManager.StopMove();
+        Plugin.StopAllMovementLocal();
     }
 }

--- a/MasterOfPuppets/Ipc/IpcProvider.WindowLayout.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.WindowLayout.cs
@@ -12,7 +12,7 @@ internal partial class IpcProvider {
 
     /// <summary>Returns a snapshot of currently known connected peers (from PeerCharacterData).</summary>
     public IReadOnlyList<PeerCharacterInfo> GetConnectedPeers()
-        => PeerCharacterData.Values.OrderBy(p => p.ContentId).ToList();
+        => GetFreshPeerCharacterData();
 
     //  Apply Layout
 

--- a/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
+++ b/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Numerics;
 
 using MasterOfPuppets.Formations;
+using MasterOfPuppets.Movement;
 
 namespace MasterOfPuppets;
 
@@ -21,9 +22,17 @@ public sealed class FormationMacroGeneratorOptions {
     public bool ClosedLoop { get; set; } = true;
     public int Step { get; set; } = 1;
     public bool Reverse { get; set; }
+    public MovementArrivalMode FormationMoveArrivalMode { get; set; } = MovementArrivalMode.Continuous;
+    public FormationMoveAnchorMode FormationMoveAnchorMode { get; set; } = FormationMoveAnchorMode.Self;
     public int Precision { get; set; } = 2;
     public bool UseMatchingGroups { get; set; }
     public string PetActionCommand { get; set; } = "/pac \"Place\" <t>";
+    public bool LinkPetTraversalToMovement { get; set; } = true;
+    public int PetStep { get; set; } = 1;
+    public bool PetReverse { get; set; }
+    public bool TransformRelativeMovesByOriginRotation { get; set; }
+    public bool EmitRelativeMoveFacing { get; set; }
+    public float OriginRotationRadians { get; set; }
 }
 
 public enum FormationMacroGeneratorMode {
@@ -112,9 +121,11 @@ public static class FormationMacroGenerator {
         var step = Math.Max(1, options.Step);
         var waitOrder = SequenceFrom(destinations[0].Index, destinations, step, options.Reverse);
         var waits = SegmentDelays(waitOrder, anchor, options);
+        var arrivalMode = options.FormationMoveArrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous";
+        var anchorMode = options.FormationMoveAnchorMode == FormationMoveAnchorMode.Target ? " target" : string.Empty;
         var lines = new List<string>();
         for (var i = 0; i < waits.Count; i++) {
-            lines.Add($"/mopformationmove \"{EscapeQuotedArgument(formationName)}\" {direction} {step} {i}");
+            lines.Add($"/mopformationmove \"{EscapeQuotedArgument(formationName)}\" {direction} {step} {i} {arrivalMode}{anchorMode}");
             lines.Add($"/mopwait {waits[i].ToString("F2", CultureInfo.InvariantCulture)}");
         }
 
@@ -144,13 +155,17 @@ public static class FormationMacroGenerator {
 
             for (int i = 0; i < order.Count; i++) {
                 var point = order[i].Point;
-                var relative = point.Offset - anchor.Offset;
-                lines.Add(
+                var (relative, facing) = BuildRelativeMove(anchor, point, options);
+                var line =
                     "/mopmoverelativeto "
                     + $"{Format(relative.X, options.Precision)} "
                     + $"{Format(relative.Y, options.Precision)} "
                     + $"{Format(relative.Z, options.Precision)} "
-                    + $"\"{options.OriginReference}\"");
+                    + $"\"{options.OriginReference}\"";
+                if (facing.HasValue)
+                    line += $" {Format(facing.Value, options.Precision)}";
+
+                lines.Add(line);
                 lines.Add($"/mopwait {waits[i].ToString("F2", CultureInfo.InvariantCulture)}");
             }
 
@@ -163,6 +178,24 @@ public static class FormationMacroGenerator {
         }
     }
 
+    private static (Vector3 Offset, float? FacingDegrees) BuildRelativeMove(
+        FormationPoint anchor,
+        FormationPoint point,
+        FormationMacroGeneratorOptions options) {
+        if (!options.TransformRelativeMovesByOriginRotation)
+            return (point.Offset - anchor.Offset, null);
+
+        var (position, rotation) = FormationMath.GetMopRelativeWorld(
+            anchor,
+            point,
+            Vector3.Zero,
+            options.OriginRotationRadians);
+        var facing = options.EmitRelativeMoveFacing
+            ? FormationMath.NormalizeDegrees(rotation * 180f / MathF.PI)
+            : (float?)null;
+        return (position, facing);
+    }
+
     private static void AddPetPlacementCommands(
         Macro macro,
         IReadOnlyList<IndexedPoint> destinations,
@@ -171,13 +204,14 @@ public static class FormationMacroGenerator {
         IReadOnlyList<CidGroup>? groups,
         IReadOnlyList<Character>? characters,
         List<string> warnings) {
-        var step = Math.Max(1, options.Step);
+        var step = Math.Max(1, options.LinkPetTraversalToMovement ? options.Step : options.PetStep);
+        var reverse = options.LinkPetTraversalToMovement ? options.Reverse : options.PetReverse;
         foreach (var start in destinations) {
             var assignment = BuildAssignment(start.Point, groups, options.UseMatchingGroups);
             if (assignment.IsEmpty)
                 continue;
 
-            var order = SequenceFrom(start.Index, destinations, step, options.Reverse);
+            var order = SequenceFrom(start.Index, destinations, step, reverse);
             var waits = SegmentDelays(order, anchor, options);
             var lines = new List<string>();
 
@@ -310,8 +344,11 @@ public static class FormationMacroGenerator {
     private static int PositiveMod(int value, int mod) =>
         (value % mod + mod) % mod;
 
-    private static string Format(float value, int precision) =>
-        value.ToString($"F{Math.Clamp(precision, 0, 6)}", CultureInfo.InvariantCulture);
+    private static string Format(float value, int precision) {
+        if (MathF.Abs(value) < 0.000001f)
+            value = 0f;
+        return value.ToString($"F{Math.Clamp(precision, 0, 6)}", CultureInfo.InvariantCulture);
+    }
 
     private sealed record IndexedPoint(int Index, FormationPoint Point);
     private sealed record CommandAssignment(List<ulong> Cids, List<string> GroupIds) {

--- a/MasterOfPuppets/MopMacro/MacroHandler.Movement.cs
+++ b/MasterOfPuppets/MopMacro/MacroHandler.Movement.cs
@@ -1,8 +1,10 @@
 using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 
+using MasterOfPuppets.Formations;
 using MasterOfPuppets.Movement;
 using MasterOfPuppets.Util;
 
@@ -15,7 +17,8 @@ public partial class MacroHandler {
         int Step,
         int SequenceIndex,
         MovementArrivalMode ArrivalMode,
-        string? InvalidArrivalModeArgument);
+        FormationMoveAnchorMode AnchorMode,
+        string? InvalidArgument);
 
     public static FormationMoveCommandOptions? ParseFormationMoveCommandArgs(string args) {
         var parts = ArgumentParser.ParseMacroArgs(args);
@@ -34,17 +37,22 @@ public partial class MacroHandler {
             sequenceIndex = 0;
 
         var arrivalMode = MovementArrivalMode.Continuous;
-        string? invalidArrivalMode = null;
-        if (parts.Count >= 5) {
-            if (parts[4].Equals("precise", System.StringComparison.OrdinalIgnoreCase))
+        var anchorMode = FormationMoveAnchorMode.Self;
+        string? invalidArgument = null;
+        foreach (var part in parts.Skip(4)) {
+            if (part.Equals("precise", System.StringComparison.OrdinalIgnoreCase))
                 arrivalMode = MovementArrivalMode.Precise;
-            else if (parts[4].Equals("continuous", System.StringComparison.OrdinalIgnoreCase))
+            else if (part.Equals("continuous", System.StringComparison.OrdinalIgnoreCase))
                 arrivalMode = MovementArrivalMode.Continuous;
+            else if (part.Equals("target", System.StringComparison.OrdinalIgnoreCase))
+                anchorMode = FormationMoveAnchorMode.Target;
+            else if (part.Equals("self", System.StringComparison.OrdinalIgnoreCase))
+                anchorMode = FormationMoveAnchorMode.Self;
             else
-                invalidArrivalMode = parts[4];
+                invalidArgument ??= part;
         }
 
-        return new FormationMoveCommandOptions(parts[0], reverse, step, sequenceIndex, arrivalMode, invalidArrivalMode);
+        return new FormationMoveCommandOptions(parts[0], reverse, step, sequenceIndex, arrivalMode, anchorMode, invalidArgument);
     }
 
     /// <summary>
@@ -103,8 +111,8 @@ public partial class MacroHandler {
     }
 
     /// <summary>
-    /// /mopformationmove "Formation Name" [forward|backward] [stride] [sequenceIndex] [precise]
-    /// Broadcasts one saved-formation movement step from the current/origin character.
+    /// /mopformationmove "Formation Name" [forward|backward] [stride] [sequenceIndex] [continuous|precise] [self|target]
+    /// Broadcasts one saved-formation movement step from the selected anchor.
     /// </summary>
     private async Task HandleMopFormationMove(string macroId, string args, CancellationToken token) {
         var options = ParseFormationMoveCommandArgs(args);
@@ -113,17 +121,18 @@ public partial class MacroHandler {
             return;
         }
 
-        if (options.InvalidArrivalModeArgument != null)
-            DalamudApi.PluginLog.Warning($"[mopformationmove] invalid arrival mode: \"{options.InvalidArrivalModeArgument}\"");
+        if (options.InvalidArgument != null)
+            DalamudApi.PluginLog.Warning($"[mopformationmove] invalid argument: \"{options.InvalidArgument}\"");
 
         await Plugin.IpcProvider.ExecuteFormationMove(
             options.FormationName,
             options.Reverse,
             options.Step,
             options.SequenceIndex,
-            options.ArrivalMode);
+            options.ArrivalMode,
+            options.AnchorMode);
         DalamudApi.PluginLog.Debug(
-            $"[mopformationmove] formation=\"{options.FormationName}\" reverse={options.Reverse} stride={options.Step} sequenceIndex={options.SequenceIndex} arrivalMode={options.ArrivalMode}");
+            $"[mopformationmove] formation=\"{options.FormationName}\" reverse={options.Reverse} stride={options.Step} sequenceIndex={options.SequenceIndex} arrivalMode={options.ArrivalMode} anchorMode={options.AnchorMode}");
     }
 
     /// <summary>/mopmovetotarget - moves to the current target's world position.</summary>
@@ -147,8 +156,7 @@ public partial class MacroHandler {
 
     /// <summary>/mopstopmove - immediately stops all movement and clears pending waypoints.</summary>
     private Task HandleMopStopMove(string macroId, string args, CancellationToken token) {
-        Plugin.SimpleInputMovement.StopMove();
-        Plugin.MovementManager.StopMove();
+        Plugin.StopAllMovementLocal();
         DalamudApi.PluginLog.Debug("[mopstopmove]");
         return Task.CompletedTask;
     }

--- a/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
+++ b/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
@@ -1178,18 +1178,20 @@ public static class MopCommandsHelper {
         new MopAction
         {
             Category = MopActionCategory.MacroAction,
-            TextCommand = "/mopformationmove \"Formation Name\" [forward|backward] [stride] [sequenceIndex] [precise]",
+            TextCommand = "/mopformationmove \"Formation Name\" [forward|backward] [stride] [sequenceIndex] [continuous|precise] [self|target]",
             SuggestionCommand = "/mopformationmove \"Formation Name\" forward 1 0",
             Example = """
             /mopformationmove "Circle" forward 1 0
             /mopformationmove "Circle" backward 2 3
             /mopformationmove "Circle" forward 1 0 precise
+            /mopformationmove "Circle" forward 1 0 precise target
             """,
             Notes = """
             Broadcasts one saved-formation movement step from the current character.
             Stride is the skip amount through formation point order; sequenceIndex is the zero-based step to execute from each recipient's computed path.
             By default, movement is continuous for smoother looping animations.
             Add precise to walk near the destination and hard-stop on arrival.
+            Add target to anchor the movement at your current target.
             Generated formation macros use one line per movement so waits, pet actions, and other macro actions can run between moves.
             """
         },

--- a/MasterOfPuppets/Plugin.cs
+++ b/MasterOfPuppets/Plugin.cs
@@ -87,6 +87,7 @@ public class Plugin : IDalamudPlugin {
         FollowPath.Update(framework);
         MovementManager.Update();
         KeyboardBroadcastManager.Update();
+        IpcProvider.UpdateCharacterDataHeartbeat();
 
         if (Config.AutoAcceptPartyInvite || Config.AutoAcceptTeleport) {
             var charConfig = Config.Characters.FirstOrDefault(c => c.Cid == DalamudApi.PlayerState.ContentId);
@@ -94,12 +95,18 @@ public class Plugin : IDalamudPlugin {
                 Config.AutoAcceptPartyInvite && (charConfig?.AutoAcceptPartyInvite ?? true),
                 Config.AutoAcceptTeleport && (charConfig?.AutoAcceptTeleport ?? true),
                 Config.AutoAcceptPartyInviteOnlyFromCharacters,
-                Config.Characters.Select(c => c.Name));
+                Config.Characters,
+                IpcProvider.GetFreshPeerCharacterData());
         }
     }
 
     private static void OnLanguageChange(string langCode) {
         Language.Culture = new CultureInfo(langCode);
+    }
+
+    internal void StopAllMovementLocal() {
+        SimpleInputMovement.StopMove();
+        MovementManager.StopMove();
     }
 
     private void OnLogin() {

--- a/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
+++ b/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
@@ -8,6 +8,7 @@ using Dalamud.Interface.ImGuiNotification;
 
 using MasterOfPuppets.Extensions;
 using MasterOfPuppets.Formations;
+using MasterOfPuppets.Movement;
 using MasterOfPuppets.Util.ImGuiExt;
 
 namespace MasterOfPuppets;
@@ -19,6 +20,11 @@ public partial class MacroEditorWindow {
     private float _macroGenTravelSecondsPerUnit = 0.2f;
     private int _macroGenStep = 1;
     private bool _macroGenReverse;
+    private int _macroGenFormationMoveArrivalMode;
+    private int _macroGenFormationMoveAnchorMode;
+    private bool _macroGenLinkPetTraversalToMovement = true;
+    private int _macroGenPetStep = 1;
+    private bool _macroGenPetReverse;
     private string _macroGenPetActionCommand = "/pac \"Place\" <t>";
 
     private FormationShapeType _macroGenShapeType = FormationShapeType.Circle;
@@ -32,10 +38,13 @@ public partial class MacroEditorWindow {
     private float _macroGenShapeAngleOffset;
     private int _macroGenShapeParamInt = 4;
     private int _macroGenShapeFaceMode = (int)FormationShapeFaceMode.Inward;
+    private int _macroGenShapeAnchorMode = (int)FormationShapeAnchorMode.AnchorAtCenter;
 
     private static readonly string[] MacroGeneratorModeNames = ["Movement", "Pet Placement", "Movement + Pet Placement"];
     private static readonly string[] MacroGeneratorSourceNames = ["Existing Formation", "Generated Shape"];
     private static readonly string[] MacroGeneratorDirectionNames = ["Forward through point order", "Backward through point order"];
+    private static readonly string[] MacroGeneratorArrivalModeNames = ["Continuous", "Precise"];
+    private static readonly string[] MacroGeneratorAnchorModeNames = ["Self", "Current target"];
 
     private void DrawMacroCommandGeneratorModal() {
         ImGui.SetNextWindowSize(new Vector2(520f, 0f), ImGuiCond.FirstUseEver);
@@ -135,21 +144,21 @@ public partial class MacroEditorWindow {
 
     private void DrawMacroGeneratorMovementControls() {
         var originName = GetLocalPlayerNameWorld();
-        DrawMacroGeneratorLabel("Movement origin", "$me and $target are resolved separately by every client that receives a macro. Generated static movement commands use the current local character name directly.");
+        DrawMacroGeneratorLabel("Movement origin", "Generated movement is anchored from the current character. Target anchoring for existing formations is configured under Advanced.");
         ImGui.TextDisabled(string.IsNullOrWhiteSpace(originName) ? "Could not resolve current character." : originName);
 
         if (_macroGenSource == 0) {
             ImGui.TextDisabled("Existing formations insert one origin command with one movement line per step.");
-            ImGuiUtil.HelpMarker("Each /mopformationmove line broadcasts one saved-formation target. Waits are calculated from saved point-to-point path distance using the same cadence as mop_scripts.");
+            ImGuiUtil.HelpMarker("Each line broadcasts one /mopformationmove step. Waits use saved point-to-point distance.");
         }
 
-        DrawMacroGenFloat("Seconds per unit", "Movement wait time per yalms/meters of path distance. Higher values move more slowly.", ref _macroGenTravelSecondsPerUnit, 0.01f, 0.01f, 10f, "%.2f");
-        DrawMacroGeneratorLabel("Global delay", "Read from Settings > Global delay between actions. It is subtracted from generated /mopwait values because the macro engine applies it after each movement command.");
+        DrawMacroGenFloat("Seconds per unit", "Wait seconds per unit of path distance.", ref _macroGenTravelSecondsPerUnit, 0.01f, 0.01f, 10f, "%.2f");
+        DrawMacroGeneratorLabel("Global delay", "Subtracted from /mopwait because the macro engine adds it after each command.");
         ImGui.TextDisabled($"{Plugin.Config.DelayBetweenActions:F2}s");
     }
 
     private void DrawMacroGeneratorPetControls() {
-        DrawMacroGeneratorLabel("Pet action", "Command run after targeting each destination character. Examples: /pac \"Place\" <t> or /moppetbarslot 1.");
+        DrawMacroGeneratorLabel("Pet action", "Command to run after targeting each destination.");
         ImGui.SetNextItemWidth(220);
         ImGui.InputText("##macroGenPetAction", ref _macroGenPetActionCommand, 256);
     }
@@ -160,21 +169,25 @@ public partial class MacroEditorWindow {
             _macroGenLastShapeAssignmentFormationIndex = _macroGenFormationIndex;
         }
 
-        DrawMacroGeneratorLabel("Shape", "The shape to generate. Character assignments are copied from the selected formation by point number.");
+        DrawMacroGeneratorLabel("Shape", "Shape used to create movement points.");
         ImGui.SetNextItemWidth(220);
         int shapeTypeInt = (int)_macroGenShapeType;
         if (ImGui.Combo("##macroGenShape", ref shapeTypeInt, FormationShapeGenerator.ShapeNames, FormationShapeGenerator.ShapeNames.Length))
             _macroGenShapeType = (FormationShapeType)shapeTypeInt;
 
         _macroGenShapeCount = Math.Max(1, _macroGenShapeCount);
-        DrawMacroGenInt("Point count", "Number of generated shape points. If this differs from the assignment formation, unmatched points are left unassigned.", ref _macroGenShapeCount, 1, 64);
+        DrawMacroGenInt("Point count", "Number of generated points.", ref _macroGenShapeCount, 1, 64);
         if (_macroGenShapeCount != assignmentPointCount)
             ImGui.TextDisabled("Assignments are copied by point index; unmatched shape points are unassigned.");
 
+        DrawMacroGeneratorLabel("Anchor mode", "Where point 1 is placed in the generated shape.");
+        ImGui.SetNextItemWidth(180);
+        ImGui.Combo("##macroGenShapeAnchor", ref _macroGenShapeAnchorMode, FormationShapeGenerator.AnchorModeNames, FormationShapeGenerator.AnchorModeNames.Length);
+
         DrawMacroGeneratorShapeParameterControls();
 
-        DrawMacroGenFloat("Rotation offset", "Rotates the generated shape before commands are created.", ref _macroGenShapeAngleOffset, 1f, -180f, 180f, "%.0f deg");
-        DrawMacroGeneratorLabel("Facing", "How generated points face in the shape. This is preserved if the generated shape is later saved as a formation.");
+        DrawMacroGenFloat("Rotation offset", "Rotates generated points before commands are created.", ref _macroGenShapeAngleOffset, 1f, -180f, 180f, "%.0f deg");
+        DrawMacroGeneratorLabel("Facing", "Facing direction assigned to generated points.");
         ImGui.SetNextItemWidth(160);
         ImGui.Combo("##macroGenShapeFace", ref _macroGenShapeFaceMode, FormationShapeGenerator.FaceModeNames, FormationShapeGenerator.FaceModeNames.Length);
     }
@@ -263,13 +276,44 @@ public partial class MacroEditorWindow {
         if (!ImGui.CollapsingHeader("Advanced##macroGenAdvanced"))
             return;
 
-        DrawMacroGenInt("Point stride", "Skip amount through formation point order. The default of 1 visits every point in saved order; 2 visits every second point.", ref _macroGenStep, 1, 64);
+        var movementEnabled = _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement;
+        var petEnabled = _macroGenMode != (int)FormationMacroGeneratorMode.Movement;
+        var existingFormationMovement = _macroGenSource == 0 && movementEnabled;
 
-        DrawMacroGeneratorLabel("Path direction", "Order each character visits points. Forward follows saved point order; backward follows the reverse saved point order.");
-        var direction = _macroGenReverse ? 1 : 0;
-        ImGui.SetNextItemWidth(220);
-        if (ImGui.Combo("##macroGenDirection", ref direction, MacroGeneratorDirectionNames, MacroGeneratorDirectionNames.Length))
-            _macroGenReverse = direction == 1;
+        if (movementEnabled) {
+            DrawMacroGenInt("Movement stride", "Point skip amount for movement steps.", ref _macroGenStep, 1, 64);
+
+            DrawMacroGeneratorLabel("Movement direction", "Point order for movement steps.");
+            var direction = _macroGenReverse ? 1 : 0;
+            ImGui.SetNextItemWidth(220);
+            if (ImGui.Combo("##macroGenDirection", ref direction, MacroGeneratorDirectionNames, MacroGeneratorDirectionNames.Length))
+                _macroGenReverse = direction == 1;
+        }
+
+        if (existingFormationMovement) {
+            DrawMacroGeneratorLabel("Movement arrival", "Continuous keeps movement smooth; precise hard-stops near each point.");
+            ImGui.SetNextItemWidth(160);
+            ImGui.Combo("##macroGenFormationMoveArrival", ref _macroGenFormationMoveArrivalMode, MacroGeneratorArrivalModeNames, MacroGeneratorArrivalModeNames.Length);
+
+            DrawMacroGeneratorLabel("Movement anchor", "Use self position or current target position as the live anchor.");
+            ImGui.SetNextItemWidth(160);
+            ImGui.Combo("##macroGenFormationMoveAnchor", ref _macroGenFormationMoveAnchorMode, MacroGeneratorAnchorModeNames, MacroGeneratorAnchorModeNames.Length);
+        }
+
+        if (petEnabled) {
+            DrawMacroGeneratorLabel("Pet follows movement", "Use movement stride and direction for pet targeting.");
+            ImGui.Checkbox("##macroGenLinkPetTraversal", ref _macroGenLinkPetTraversalToMovement);
+
+            if (!_macroGenLinkPetTraversalToMovement) {
+                DrawMacroGenInt("Pet stride", "Point skip amount for pet targets.", ref _macroGenPetStep, 1, 64);
+
+                DrawMacroGeneratorLabel("Pet direction", "Point order for pet targets.");
+                var petDirection = _macroGenPetReverse ? 1 : 0;
+                ImGui.SetNextItemWidth(220);
+                if (ImGui.Combo("##macroGenPetDirection", ref petDirection, MacroGeneratorDirectionNames, MacroGeneratorDirectionNames.Length))
+                    _macroGenPetReverse = petDirection == 1;
+            }
+        }
 
         ImGui.TextDisabled("Generated commands always loop. The final wait is timed back to the first destination before /moploop.");
     }
@@ -311,6 +355,8 @@ public partial class MacroEditorWindow {
         var movementEnabled = _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement;
         if (_macroGenSource == 1 && movementEnabled && string.IsNullOrWhiteSpace(GetLocalPlayerNameWorld()))
             return new MacroCommandGeneratorPreview(false, "Current character name/world must be resolved before generated shape movement commands can be created.", []);
+        if (_macroGenSource == 1 && movementEnabled && GetLocalPlayerRotation() == null)
+            return new MacroCommandGeneratorPreview(false, "Current character rotation must be resolved before generated shape movement commands can be created.", []);
 
         var result = GenerateMacroCommands(sourceFormation, originPointIndex);
         if (result.Macro.Commands.Count == 0)
@@ -355,9 +401,17 @@ public partial class MacroEditorWindow {
                 GlobalDelaySeconds = Math.Max(0f, (float)Plugin.Config.DelayBetweenActions),
                 Step = _macroGenStep,
                 Reverse = _macroGenReverse,
+                FormationMoveArrivalMode = _macroGenFormationMoveArrivalMode == 1 ? MovementArrivalMode.Precise : MovementArrivalMode.Continuous,
+                FormationMoveAnchorMode = _macroGenFormationMoveAnchorMode == 1 ? FormationMoveAnchorMode.Target : FormationMoveAnchorMode.Self,
                 ClosedLoop = true,
                 UseMatchingGroups = false,
                 PetActionCommand = string.IsNullOrWhiteSpace(_macroGenPetActionCommand) ? "/pac \"Place\" <t>" : _macroGenPetActionCommand.Trim(),
+                LinkPetTraversalToMovement = _macroGenLinkPetTraversalToMovement,
+                PetStep = _macroGenPetStep,
+                PetReverse = _macroGenPetReverse,
+                TransformRelativeMovesByOriginRotation = _macroGenSource == 1 && _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement,
+                EmitRelativeMoveFacing = _macroGenSource == 1 && _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement,
+                OriginRotationRadians = GetLocalPlayerRotation() ?? 0f,
             },
             Plugin.Config.CidsGroups,
             Plugin.Config.Characters);
@@ -407,6 +461,7 @@ public partial class MacroEditorWindow {
                 AngleOffsetDegrees = _macroGenShapeAngleOffset,
                 IntParameter = _macroGenShapeParamInt,
                 FaceMode = (FormationShapeFaceMode)_macroGenShapeFaceMode,
+                AnchorMode = (FormationShapeAnchorMode)_macroGenShapeAnchorMode,
             }),
         };
 
@@ -447,6 +502,9 @@ public partial class MacroEditorWindow {
             return string.Empty;
         }
     }
+
+    private static float? GetLocalPlayerRotation() =>
+        DalamudApi.ObjectTable.LocalPlayer?.Rotation;
 
     private sealed record MacroCommandGeneratorPreview(bool CanInsert, string Message, List<string> Warnings);
 }

--- a/MasterOfPuppets/Ui/Windows/PeerMonitorWindow.cs
+++ b/MasterOfPuppets/Ui/Windows/PeerMonitorWindow.cs
@@ -8,6 +8,8 @@ using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 
+using MasterOfPuppets.Ipc;
+
 namespace MasterOfPuppets;
 
 public class PeerMonitorWindow : Window {
@@ -64,9 +66,7 @@ public class PeerMonitorWindow : Window {
         ImGui.Separator();
 
         //  Table
-        var offlineThreshold = _autoRefresh
-            ? TimeSpan.FromSeconds(RefreshTotalSeconds * 2.5)
-            : TimeSpan.FromMinutes(10);
+        var inviteFilterFreshThreshold = IpcProvider.PeerCharacterDataMaxAge;
 
         using var table = ImRaii.Table(
             "##peers", 6,
@@ -76,7 +76,7 @@ public class PeerMonitorWindow : Window {
 
         ImGui.TableSetupScrollFreeze(0, 1);
         ImGui.TableSetupColumn("#", ImGuiTableColumnFlags.WidthFixed, 20);
-        ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 20);
+        ImGui.TableSetupColumn("Fresh", ImGuiTableColumnFlags.WidthFixed, 45);
         ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch);
         ImGui.TableSetupColumn("Home World", ImGuiTableColumnFlags.WidthFixed, 120);
         ImGui.TableSetupColumn("Current World", ImGuiTableColumnFlags.WidthFixed, 120);
@@ -89,10 +89,10 @@ public class PeerMonitorWindow : Window {
             ImGui.TableNextColumn();
             ImGui.Text($"{index + 1:00}");
 
-            // Status icon
+            // Freshness uses the same threshold as auto-accept invite filtering.
             ImGui.TableNextColumn();
-            var isOnline = DateTime.UtcNow - info.LastSeen < offlineThreshold;
-            var (icon, color) = isOnline
+            var isFreshForInviteFilter = DateTime.UtcNow - info.LastSeen <= inviteFilterFreshThreshold;
+            var (icon, color) = isFreshForInviteFilter
                 ? (FontAwesomeIcon.Check, Style.Colors.Green)
                 : (FontAwesomeIcon.Times, Style.Colors.Red);
             using (ImRaii.PushColor(ImGuiCol.Text, color)) {

--- a/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
+++ b/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
@@ -18,36 +18,45 @@ public class AutoLoginPlannerTests {
     }
 
     [Fact]
-    public void BuildWorldQueue_UsesCurrentWorldForMatchingCharacter() {
-        var queue = AutoLoginPlanner.BuildWorldQueue(
+    public void ResolveTarget_UsesCurrentWorldForMatchingCharacter() {
+        var target = AutoLoginPlanner.ResolveTarget(
             [new AutoLoginCandidate(42, "Test Character")],
             [
                 LobbyEntry(42, "Test Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos"),
                 LobbyEntry(100, "Other Character", currentWorld: "Diabolos", homeWorld: "Diabolos"),
-            ],
-            ["Diabolos", "Halicarnassus", "Maduin"]);
+            ]);
 
-        Assert.Equal(["Halicarnassus", "Diabolos"], queue);
+        Assert.NotNull(target);
+        Assert.Equal("Test Character", target.Value.CharacterName);
+        Assert.Equal("Halicarnassus", target.Value.WorldName);
     }
 
     [Fact]
-    public void BuildWorldQueue_DoesNotAddWorldsWithoutLobbyCharacters() {
-        var queue = AutoLoginPlanner.BuildWorldQueue(
-            [new AutoLoginCandidate(999, "Missing Character")],
-            [LobbyEntry(42, "Other Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos")],
-            ["Diabolos", "Halicarnassus", "Maduin"]);
+    public void ResolveTarget_MatchesByNameWhenContentIdIsMissing() {
+        var target = AutoLoginPlanner.ResolveTarget(
+            [new AutoLoginCandidate(0, "Test Character")],
+            [LobbyEntry(42, "Test Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos")]);
 
-        Assert.Equal(["Halicarnassus"], queue);
+        Assert.NotNull(target);
+        Assert.Equal("Halicarnassus", target.Value.WorldName);
     }
 
     [Fact]
-    public void BuildWorldQueue_FallsBackToAllVisibleWorldsWhenLobbyEntriesUnavailable() {
-        var queue = AutoLoginPlanner.BuildWorldQueue(
+    public void ResolveTarget_DoesNotFallbackToOtherLobbyCharacters() {
+        var target = AutoLoginPlanner.ResolveTarget(
             [new AutoLoginCandidate(999, "Missing Character")],
-            [],
-            ["Diabolos", "Halicarnassus"]);
+            [LobbyEntry(42, "Other Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos")]);
 
-        Assert.Equal(["Diabolos", "Halicarnassus"], queue);
+        Assert.Null(target);
+    }
+
+    [Fact]
+    public void ResolveTarget_DoesNotFallbackWhenLobbyEntriesUnavailable() {
+        var target = AutoLoginPlanner.ResolveTarget(
+            [new AutoLoginCandidate(999, "Missing Character")],
+            []);
+
+        Assert.Null(target);
     }
 
     [Fact]

--- a/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
+++ b/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 
 using MasterOfPuppets;
 using MasterOfPuppets.Formations;
+using MasterOfPuppets.Movement;
 
 using Xunit;
 
@@ -38,6 +39,54 @@ public class FormationMacroGeneratorTests {
         Assert.Equal("/mopmoverelativeto 0.00 0.00 2.00 \"Origin Character@World\"", lines[4]);
         Assert.Equal("/mopwait 4.00", lines[5]);
         Assert.Equal("/moploop", lines[6]);
+    }
+
+    [Fact]
+    public void GenerateLoopMacro_CanBakeOriginRotationIntoRelativeMoveCoordinatesAndFacing() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Offset = Vector3.Zero, Angle = 0f, Cids = [100] },
+                new FormationPoint { Offset = new Vector3(0f, 0f, 2f), Angle = 90f, Cids = [101] },
+            ],
+        };
+
+        var macro = FormationMacroGenerator.GenerateLoopMacro(formation, new FormationMacroGeneratorOptions {
+            OriginReference = "Origin Character@World",
+            TransformRelativeMovesByOriginRotation = true,
+            EmitRelativeMoveFacing = true,
+            OriginRotationRadians = MathF.PI / 2f,
+            TravelSecondsPerUnit = 1f,
+            GlobalDelaySeconds = 0f,
+        });
+
+        var lines = macro.Commands[0].Actions.Split('\n');
+        Assert.Equal("/mopmoverelativeto 2.00 0.00 0.00 \"Origin Character@World\" 180.00", lines[0]);
+        Assert.DoesNotContain("/mopformationmove", macro.Commands[0].Actions);
+    }
+
+    [Fact]
+    public void GenerateLoopMacro_GeneratedShapeStyleMovement_UsesStaticRelativeMoveCommands() {
+        var formation = new Formation {
+            Points = FormationShapeGenerator.Generate(new FormationShapeSpec {
+                Type = FormationShapeType.Circle,
+                Count = 4,
+                Radius = 2f,
+                AnchorMode = FormationShapeAnchorMode.AnchorAtCenter,
+                AssignedCids = [100, 101, 102, 103],
+            }),
+        };
+
+        var macro = FormationMacroGenerator.GenerateLoopMacro(formation, new FormationMacroGeneratorOptions {
+            OriginReference = "Origin Character@World",
+            TransformRelativeMovesByOriginRotation = true,
+            EmitRelativeMoveFacing = true,
+            OriginRotationRadians = 0f,
+        });
+
+        Assert.Equal(3, macro.Commands.Count);
+        var lines = macro.Commands[0].Actions.Split('\n');
+        Assert.Equal("/mopmoverelativeto 0.00 0.00 -2.00 \"Origin Character@World\" -180.00", lines[0]);
+        Assert.DoesNotContain("/mopformationmove", macro.Commands[0].Actions);
     }
 
     [Fact]
@@ -311,9 +360,34 @@ public class FormationMacroGeneratorTests {
             .Where(line => line.StartsWith("/mopformationmove"))
             .ToArray();
         Assert.Equal(7, moves.Length);
-        Assert.Equal("/mopformationmove \"Circle\" forward 1 0", moves[0]);
-        Assert.Equal("/mopformationmove \"Circle\" forward 1 6", moves[6]);
+        Assert.Equal("/mopformationmove \"Circle\" forward 1 0 continuous", moves[0]);
+        Assert.Equal("/mopformationmove \"Circle\" forward 1 6 continuous", moves[6]);
         Assert.EndsWith("/moploop", command.Actions);
+    }
+
+    [Fact]
+    public void GenerateLoopMacro_ExistingFormationMovement_EmitsArrivalAndTargetAnchor() {
+        var formation = BuildEightPointFormation();
+
+        var result = FormationMacroGenerator.GenerateLoopMacroWithDiagnostics(
+            formation,
+            new FormationMacroGeneratorOptions {
+                Mode = FormationMacroGeneratorMode.Movement,
+                AnchorPointIndex = 0,
+                UseFormationMoveCommand = true,
+                FormationMoveName = "Circle",
+                OriginContentId = 100,
+                FormationMoveArrivalMode = MovementArrivalMode.Precise,
+                FormationMoveAnchorMode = FormationMoveAnchorMode.Target,
+            });
+
+        var command = Assert.Single(result.Macro.Commands);
+        var moves = command.Actions
+            .Split('\n')
+            .Where(line => line.StartsWith("/mopformationmove"))
+            .ToArray();
+
+        Assert.Equal("/mopformationmove \"Circle\" forward 1 0 precise target", moves[0]);
     }
 
     [Fact]
@@ -338,9 +412,9 @@ public class FormationMacroGeneratorTests {
 
         var command = Assert.Single(result.Macro.Commands);
         var lines = command.Actions.Split('\n');
-        Assert.Equal("/mopformationmove \"Circle\" forward 1 0", lines[0]);
+        Assert.Equal("/mopformationmove \"Circle\" forward 1 0 continuous", lines[0]);
         Assert.Equal("/mopwait 0.10", lines[1]);
-        Assert.Equal("/mopformationmove \"Circle\" forward 1 1", lines[2]);
+        Assert.Equal("/mopformationmove \"Circle\" forward 1 1 continuous", lines[2]);
         Assert.Equal("/mopwait 0.10", lines[3]);
     }
 
@@ -439,12 +513,38 @@ public class FormationMacroGeneratorTests {
         Assert.Empty(result.Warnings);
         Assert.Equal(8, result.Macro.Commands.Count);
         Assert.Equal([100UL], result.Macro.Commands[0].Cids);
-        Assert.Contains("/mopformationmove \"Circle\" forward 1 0", result.Macro.Commands[0].Actions);
+        Assert.Contains("/mopformationmove \"Circle\" forward 1 0 continuous", result.Macro.Commands[0].Actions);
         Assert.DoesNotContain("/mopformationpath", result.Macro.Commands[0].Actions);
         Assert.All(result.Macro.Commands.Skip(1), command => {
             Assert.DoesNotContain(100UL, command.Cids);
             Assert.Contains("/moppetbarslot 1", command.Actions);
         });
+    }
+
+    [Fact]
+    public void GenerateLoopMacro_PetPlacement_CanUseIndependentStrideAndDirection() {
+        var formation = BuildEightPointFormation();
+        var characters = Enumerable.Range(1, 7)
+            .Select(i => new Character { Cid = (ulong)(100 + i), Name = $"Character {i}@World" })
+            .ToArray();
+
+        var result = FormationMacroGenerator.GenerateLoopMacroWithDiagnostics(
+            formation,
+            new FormationMacroGeneratorOptions {
+                Mode = FormationMacroGeneratorMode.PetPlacement,
+                AnchorPointIndex = 0,
+                OriginContentId = 100,
+                LinkPetTraversalToMovement = false,
+                PetStep = 2,
+                PetReverse = true,
+            },
+            characters: characters);
+
+        var command = Assert.Single(result.Macro.Commands, command => command.Cids.SequenceEqual([101UL]));
+        var lines = command.Actions.Split('\n');
+        Assert.Equal("/moptarget \"Character 1@World\"", lines[0]);
+        Assert.Equal("/moptarget \"Character 6@World\"", lines[3]);
+        Assert.Equal("/moptarget \"Character 4@World\"", lines[6]);
     }
 
     private static Formation BuildEightPointFormation() {

--- a/MasterOfPuppetsTests/MacroTests.cs
+++ b/MasterOfPuppetsTests/MacroTests.cs
@@ -168,6 +168,7 @@ public class MacroTests
         Assert.Equal(1, result.Step);
         Assert.Equal(0, result.SequenceIndex);
         Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Self, result.AnchorMode);
     }
 
     [Fact]
@@ -180,15 +181,41 @@ public class MacroTests
         Assert.Equal(2, result.Step);
         Assert.Equal(3, result.SequenceIndex);
         Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Precise, result.ArrivalMode);
+        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Self, result.AnchorMode);
     }
 
     [Fact]
-    public void ParseFormationMoveCommandArgs_Invalid_ArrivalMode_Falls_Back_To_Continuous()
+    public void ParseFormationMoveCommandArgs_Accepts_Target_Anchor()
+    {
+        var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 target");
+
+        Assert.NotNull(result);
+        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Target, result.AnchorMode);
+    }
+
+    [Fact]
+    public void ParseFormationMoveCommandArgs_Accepts_Precise_Target_In_Either_Order()
+    {
+        var targetLast = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 precise target");
+        var targetFirst = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 target precise");
+
+        Assert.NotNull(targetLast);
+        Assert.NotNull(targetFirst);
+        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Precise, targetLast.ArrivalMode);
+        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Target, targetLast.AnchorMode);
+        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Precise, targetFirst.ArrivalMode);
+        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Target, targetFirst.AnchorMode);
+    }
+
+    [Fact]
+    public void ParseFormationMoveCommandArgs_Invalid_Argument_Falls_Back_To_Defaults()
     {
         var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 careful");
 
         Assert.NotNull(result);
         Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Continuous, result.ArrivalMode);
-        Assert.Equal("careful", result.InvalidArrivalModeArgument);
+        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Self, result.AnchorMode);
+        Assert.Equal("careful", result.InvalidArgument);
     }
 }

--- a/MasterOfPuppetsTests/PartyInvitePromptMatcherTests.cs
+++ b/MasterOfPuppetsTests/PartyInvitePromptMatcherTests.cs
@@ -1,58 +1,232 @@
 using MasterOfPuppets;
+using MasterOfPuppets.Ipc;
 
 using Xunit;
 
 public class PartyInvitePromptMatcherTests {
-    [Theory]
-    [InlineData("Join Alice@Diabolos's party?", "Alice@Diabolos")]
-    [InlineData("Join Alice Diabolos's party?", "Alice@Diabolos")]
-    [InlineData("Join Alice (Diabolos)'s party?", "Alice@Diabolos")]
-    public void IsInviterInCharacterList_Matches_Name_And_World(string prompt, string savedCharacter) {
-        Assert.True(PartyInvitePromptMatcher.IsInviterInCharacterList(prompt, [savedCharacter]));
+    private const string PartyInviteAddonRow = "Join <string(lstr1)>'s party?";
+
+    [Fact]
+    public void TryBuildExtractionExpression_Uses_String_Payload_As_Inviter_Slot() {
+        Assert.True(PartyInvitePromptMatcher.TryBuildExtractionExpression(
+            PartyInviteAddonRow,
+            out var expression,
+            out var reason));
+
+        Assert.Equal("Join ", expression.Prefix);
+        Assert.Equal("'s party?", expression.Suffix);
+        Assert.Equal("party invite sheet expression parsed", reason);
     }
 
     [Fact]
-    public void IsInviterInCharacterList_Matches_NameOnly_Prompt_To_Saved_NameWorld() {
-        Assert.True(PartyInvitePromptMatcher.IsInviterInCharacterList(
-            "Join Alice's party?",
-            ["Alice@Diabolos"]));
+    public void TryBuildExtractionExpression_Rejects_Row_With_No_String_Payload() {
+        Assert.False(PartyInvitePromptMatcher.TryBuildExtractionExpression(
+            "Join 's party?",
+            out var expression,
+            out var reason));
+
+        Assert.Equal("Join 's party?", expression.SourceText);
+        Assert.Equal(string.Empty, expression.Prefix);
+        Assert.Equal(string.Empty, expression.Suffix);
+        Assert.Equal("party invite sheet expression has no string payload", reason);
     }
 
     [Fact]
-    public void IsInviterInCharacterList_Does_Not_NameFallback_When_Prompt_Has_World() {
-        Assert.False(PartyInvitePromptMatcher.IsInviterInCharacterList(
+    public void ParsePartyInvitePrompt_Extracts_Inviter_From_Addon_Row_Expression() {
+        var result = PartyInvitePromptMatcher.ParsePartyInvitePrompt(
+            "Join Alice \ue0bb Diabolos's party?",
+            PartyInviteAddonRow);
+
+        Assert.True(result.IsPartyInvite);
+        Assert.True(result.SheetExpressionAvailable);
+        Assert.Equal("Alice \ue0bb Diabolos", result.InviterSegment);
+        Assert.Equal("party invite sheet expression parsed", result.SheetExpressionReason);
+    }
+
+    [Fact]
+    public void ParsePartyInvitePrompt_Rejects_When_Sheet_Expression_Is_Unavailable() {
+        var result = PartyInvitePromptMatcher.ParsePartyInvitePrompt(
             "Join Alice@Diabolos's party?",
-            ["Alice@Excalibur"]));
+            string.Empty);
+
+        Assert.False(result.IsPartyInvite);
+        Assert.False(result.SheetExpressionAvailable);
+        Assert.Equal("party invite sheet expression unavailable", result.Reason);
     }
 
     [Fact]
-    public void IsInviterInCharacterList_Does_Not_Match_NonParty_Prompt() {
-        Assert.False(PartyInvitePromptMatcher.IsInviterInCharacterList(
+    public void ParsePartyInvitePrompt_Rejects_NonParty_Prompt() {
+        var result = PartyInvitePromptMatcher.ParsePartyInvitePrompt(
             "Accept Teleport to Limsa Lominsa?",
-            ["Alice@Diabolos"]));
+            PartyInviteAddonRow);
+
+        Assert.False(result.IsPartyInvite);
+        Assert.True(result.SheetExpressionAvailable);
+        Assert.Equal("prompt does not start with expression prefix", result.Reason);
     }
 
     [Fact]
-    public void ShouldAcceptPartyInvite_Allows_PartyInvite_When_Whitelist_Disabled() {
-        Assert.True(PartyInvitePromptMatcher.ShouldAcceptPartyInvite(
-            "Join Alice@Diabolos's party?",
-            onlyFromCharacters: false,
-            characterNames: []));
-    }
-
-    [Fact]
-    public void ShouldAcceptPartyInvite_Blocks_NonParty_Prompt_When_Whitelist_Disabled() {
-        Assert.False(PartyInvitePromptMatcher.ShouldAcceptPartyInvite(
-            "Accept Teleport to Limsa Lominsa?",
-            onlyFromCharacters: false,
-            characterNames: []));
-    }
-
-    [Fact]
-    public void TryGetPartyInviteInviterSegment_Extracts_Inviter() {
+    public void TryGetPartyInviteInviterSegment_Extracts_Inviter_With_Sheet_Expression() {
         Assert.True(PartyInvitePromptMatcher.TryGetPartyInviteInviterSegment(
             "Join Alice@Diabolos's party?",
+            PartyInviteAddonRow,
             out var inviter));
         Assert.Equal("Alice@Diabolos", inviter);
     }
+
+    [Fact]
+    public void LegacyPartyInviteHelpers_Do_Not_Parse_English_Without_Sheet_Expression() {
+        Assert.False(PartyInvitePromptMatcher.ShouldAcceptPartyInvite(
+            "Join Alice@Diabolos's party?",
+            onlyFromCharacters: false,
+            characterNames: []));
+
+        Assert.False(PartyInvitePromptMatcher.IsInviterInConnectedConfiguredCharacters(
+            "Join Alice@Diabolos's party?",
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", DateTime.UtcNow)]));
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Accepts_When_Peer_Is_Configured_By_Cid() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice@Diabolos's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now)],
+            now);
+
+        Assert.True(decision.ShouldAccept);
+        Assert.Contains("cid:1001", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Accepts_When_Prompt_Uses_Special_World_Separator() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice \ue0bb Diabolos's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now)],
+            now);
+
+        Assert.True(decision.ShouldAccept);
+        Assert.Equal("Alice \ue0bb Diabolos", decision.Parse.InviterSegment);
+        Assert.Contains("home world", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Accepts_NameOnly_Prompt_When_Configured_By_Cid() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now)],
+            now);
+
+        Assert.True(decision.ShouldAccept);
+        Assert.Contains("name-only prompt", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Rejects_Configured_But_Not_Connected() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice@Diabolos's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [],
+            now);
+
+        Assert.False(decision.ShouldAccept);
+        Assert.Equal("no fresh connected peer matched inviter segment", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Rejects_Connected_But_Not_Configured() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice@Diabolos's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 2002, Name = "Bob@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now)],
+            now);
+
+        Assert.False(decision.ShouldAccept);
+        Assert.Equal("Alice@Diabolos/Diabolos cid=1001", decision.MatchedPeer);
+        Assert.Contains("peer is not configured", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Accepts_NameOnly_Prompt_When_Peer_And_Config_Match() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice's party?",
+            PartyInviteAddonRow,
+            [new Character { Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now)],
+            now);
+
+        Assert.True(decision.ShouldAccept);
+        Assert.Contains("name-only prompt", decision.Reason);
+        Assert.Contains("configured character", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Rejects_World_Mismatch_When_Prompt_Has_World() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice@Excalibur's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now)],
+            now);
+
+        Assert.False(decision.ShouldAccept);
+        Assert.Equal("no fresh connected peer matched inviter segment", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Rejects_Stale_Peer() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice@Diabolos's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now - TimeSpan.FromSeconds(6))],
+            now);
+
+        Assert.False(decision.ShouldAccept);
+        Assert.Equal("no fresh connected peer matched inviter segment", decision.Reason);
+    }
+
+    [Fact]
+    public void ConnectedConfiguredInvite_Reports_Diagnostic_Counts_For_Rejection() {
+        var now = DateTime.UtcNow;
+
+        var decision = PartyInvitePromptMatcher.EvaluateConnectedConfiguredInvite(
+            "Join Alice@Diabolos's party?",
+            PartyInviteAddonRow,
+            [new Character { Cid = 1001, Name = "Alice@Diabolos" }],
+            [Peer(1001, "Alice", "Diabolos", now - TimeSpan.FromSeconds(6))],
+            now);
+
+        Assert.False(decision.ShouldAccept);
+        Assert.Equal(1, decision.ConnectedPeerCount);
+        Assert.Equal(0, decision.FreshPeerCount);
+        Assert.Equal("no fresh connected peer matched inviter segment", decision.Reason);
+    }
+
+    private static PeerCharacterInfo Peer(ulong cid, string name, string homeWorld, DateTime lastSeen) =>
+        new(cid, name, homeWorld, 0, homeWorld, 0, lastSeen);
 }

--- a/MasterOfPuppetsTests/SimpleInputMovementTests.cs
+++ b/MasterOfPuppetsTests/SimpleInputMovementTests.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 using MasterOfPuppets.Movement;
 
 using Xunit;
@@ -49,5 +51,37 @@ public class SimpleInputMovementTests {
             MovementArrivalMode.Continuous);
 
         Assert.Equal(ArrivalMovementState.Stop, state);
+    }
+
+    [Fact]
+    public void ProgressTracker_Does_Not_Report_Stuck_On_First_Sample() {
+        var tracker = new SimpleMovementProgressTracker();
+
+        var stuck = tracker.Update(Vector3.Zero, nowMs: 1_000, movementTolerance: 0.05f, timeoutMs: 500);
+
+        Assert.False(stuck);
+    }
+
+    [Fact]
+    public void ProgressTracker_Reports_Stuck_After_Timeout_Without_Significant_Movement() {
+        var tracker = new SimpleMovementProgressTracker();
+
+        Assert.False(tracker.Update(Vector3.Zero, nowMs: 1_000, movementTolerance: 0.05f, timeoutMs: 500));
+
+        var stuck = tracker.Update(new Vector3(0.01f, 0, 0), nowMs: 1_500, movementTolerance: 0.05f, timeoutMs: 500);
+
+        Assert.True(stuck);
+    }
+
+    [Fact]
+    public void ProgressTracker_Resets_Timeout_When_Position_Changes_Significantly() {
+        var tracker = new SimpleMovementProgressTracker();
+
+        Assert.False(tracker.Update(Vector3.Zero, nowMs: 1_000, movementTolerance: 0.05f, timeoutMs: 500));
+        Assert.False(tracker.Update(new Vector3(0.10f, 0, 0), nowMs: 1_400, movementTolerance: 0.05f, timeoutMs: 500));
+
+        var stuck = tracker.Update(new Vector3(0.11f, 0, 0), nowMs: 1_800, movementTolerance: 0.05f, timeoutMs: 500);
+
+        Assert.False(stuck);
     }
 }


### PR DESCRIPTION
## Summary

  Fixes several formation macro, auto-accept, movement cancellation, and auto-login issues
  discovered while testing multi-client workflows.

  ## Changes

  - Reworked party invite auto-accept filtering to parse the localized Addon SeString for the
  inviter segment instead of relying on English prompt fragments.
  - Matches party invite senders against fresh IPC peer character data and the configured
  character list, including CID, name, home world, and current world checks.
  - Adds verbose diagnostics for party invite prompt parsing, extracted inviter text, matched
  peer/config entries, and accept/reject decisions.
  - Adds periodic IPC character-data heartbeats and aligns Peer Monitor freshness with the invite
  filter window.

  - Fixes generated shape macro coordinates by projecting generated points through the same
  relative position/rotation math used by formation execution.
  - Adds `/mopformationmove` support for `continuous|precise` arrival mode and `self|target`
  anchor mode.
  - Exposes movement arrival, movement anchor, shape anchor mode, and independent pet stride/
  direction controls in Generate Commands.
  - Updates generated existing-formation macros to emit explicit arrival mode arguments.

  - Centralizes Stop Movement behavior so simple input movement and queued movement are both
  stopped locally and over IPC.
  - Improves `SimpleInputMovement` cancellation, native stop handling, framework-thread safety,
  and stale input cleanup.
  - Adds optional stuck detection for simple-input formation moves so blocked characters can stop
  instead of running indefinitely.

  - Refines auto-login to resolve a single target from lobby data instead of scanning/falling back
  through unrelated worlds.
  - Extends login confirmation timeout and treats post-selection timeout as informational.

  ## Testing

  - `dotnet test MasterOfPuppetsTests/MasterOfPuppetsTests.csproj --no-restore --logger
  "console;verbosity=minimal"`
  - Passed: 148 tests

  ## Notes

  - Teleport auto-accept remains destination-prompt based; the SelectYesno teleport payload does
  not expose the requesting character in this change.