### PR TITLE
Enqueue found character homeworlds before trying random

### DIFF
--- a/MasterOfPuppets/Game/Login/AutoLoginManager.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginManager.cs
@@ -9,6 +9,7 @@ using Dalamud.Interface.ImGuiNotification;
 using Dalamud.Plugin.Services;
 
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -17,6 +18,8 @@ using InteropGenerator.Runtime;
 namespace MasterOfPuppets;
 
 internal sealed unsafe class AutoLoginManager : IDisposable {
+    private readonly record struct WorldSelectorSnapshot(List<AutoLoginWorldEntry> Worlds, bool UsedAddonWorldEntries, int SelectedWorldIndex);
+
     private enum LoginState {
         Idle,
         WaitingTitleMenu,
@@ -166,7 +169,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
     }
 
     private void HandleWaitingTitleMenu() {
-        if (!GameDialogManager.IsAddonVisible("_TitleMenu"))
+        if (!IsTitleMenuReadyForAutoLogin())
             return;
 
         if (SendTitleAction("_TitleMenu", 3, 4)) {
@@ -188,22 +191,29 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             return;
         }
 
-        var visibleWorlds = WorldNames;
+        var worldSelectorSnapshot = ReadWorldSelectorSnapshot();
+        var visibleWorlds = worldSelectorSnapshot.Worlds;
         if (visibleWorlds.Count == 0)
             return;
 
         var lobbyEntries = ReadLobbyEntries();
-        LogWorldSelectorSnapshot(visibleWorlds, lobbyEntries);
+        LogWorldSelectorSnapshot(worldSelectorSnapshot, lobbyEntries);
         if (_worldQueue.Count == 0) {
-            _worldQueue = AutoLoginPlanner.BuildWorldQueue(_candidates, lobbyEntries, visibleWorlds);
+            var currentLobbyWorlds = GetCurrentLobbyWorlds(lobbyEntries);
+            var queueResult = AutoLoginPlanner.BuildWorldQueueWithDiagnostics(_candidates, lobbyEntries, visibleWorlds, currentLobbyWorlds);
+            _worldQueue = queueResult.Worlds;
             _worldIndex = 0;
+            DalamudApi.PluginLog.Debug(
+                $"[AutoLogin] World selector source: {(worldSelectorSnapshot.UsedAddonWorldEntries ? "AddonCharaSelectWorldServer.WorldEntries" : "StringArrays[1] fallback")}; selectedWorldIndex={worldSelectorSnapshot.SelectedWorldIndex}; currentLobbyWorlds=[{(currentLobbyWorlds.Count == 0 ? "<empty>" : string.Join(", ", currentLobbyWorlds))}].");
+            foreach (var diagnostic in queueResult.Diagnostics)
+                DalamudApi.PluginLog.Debug($"[AutoLogin] World scan diagnostic: {diagnostic}");
             DalamudApi.PluginLog.Information(
-                $"[AutoLogin] World scan queue (lobby current worlds first, then visible fallback): {(_worldQueue.Count == 0 ? "<empty>" : string.Join(", ", _worldQueue))}.");
+                $"[AutoLogin] World scan queue (lobby current worlds first, then configured home worlds, then visible fallback): {(_worldQueue.Count == 0 ? "<empty>" : string.Join(", ", _worldQueue))}.");
         }
 
         if (_worldQueue.Count == 0) {
             DalamudApi.PluginLog.Warning("[AutoLogin] Could not build an auto-login world scan queue.");
-            DalamudApi.PluginLog.Warning($"[AutoLogin] World selector snapshot: worlds={visibleWorlds.Count} [{Preview(visibleWorlds)}]; lobby={FormatLobbySnapshot(lobbyEntries)}; candidates=[{string.Join(", ", _candidates.Select(FormatCandidate))}]");
+            DalamudApi.PluginLog.Warning($"[AutoLogin] World selector snapshot: worlds={visibleWorlds.Count} [{FormatWorldSelectorSnapshot(visibleWorlds)}]; lobby={FormatLobbySnapshot(lobbyEntries)}; candidates=[{string.Join(", ", _candidates.Select(FormatCandidate))}]");
             Stop();
             return;
         }
@@ -372,7 +382,8 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
     }
 
     private string BuildStateDiagnostics() {
-        var worldNames = TryReadList(() => WorldNames);
+        var worldSelectorSnapshot = TryRead(() => ReadWorldSelectorSnapshot());
+        var worldSelectorWorlds = worldSelectorSnapshot.Worlds ?? [];
         var characterNames = TryReadList(() => CharacterNames);
         var lobbyEntries = TryReadList(ReadLobbyEntries);
 
@@ -382,7 +393,9 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             $"{FormatAddonState("_CharaSelectWorldServer")}; " +
             $"{FormatAddonState("_CharaSelectListMenu")}; " +
             $"{FormatAddonState(GameDialogManager.AddonName.SelectYesno)}; " +
-            $"worlds={worldNames.Count} [{Preview(worldNames)}]; " +
+            $"worldSelectorSource={(worldSelectorSnapshot.UsedAddonWorldEntries ? "WorldEntries" : "StringArrayFallback")}; " +
+            $"selectedWorldIndex={worldSelectorSnapshot.SelectedWorldIndex}; " +
+            $"worlds={worldSelectorWorlds.Count} [{FormatWorldSelectorSnapshot(worldSelectorWorlds)}]; " +
             $"characters={characterNames.Count} [{Preview(characterNames)}]; " +
             $"lobbyEntries={lobbyEntries.Count} [{FormatLobbySnapshot(lobbyEntries)}]; " +
             $"worldQueueIndex={_worldIndex}; worldQueue=[{string.Join(", ", _worldQueue)}]; " +
@@ -390,13 +403,13 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             $"candidates=[{string.Join(", ", _candidates.Select(FormatCandidate))}]";
     }
 
-    private void LogWorldSelectorSnapshot(IReadOnlyList<string> worldNames, IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) {
+    private void LogWorldSelectorSnapshot(WorldSelectorSnapshot snapshot, IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) {
         if (_loggedWorldSelectorSnapshot)
             return;
 
         _loggedWorldSelectorSnapshot = true;
         DalamudApi.PluginLog.Debug(
-            $"[AutoLogin] World selector snapshot: worlds={worldNames.Count} [{Preview(worldNames)}]; lobbyEntries={lobbyEntries.Count} [{FormatLobbySnapshot(lobbyEntries)}].");
+            $"[AutoLogin] World selector snapshot: source={(snapshot.UsedAddonWorldEntries ? "WorldEntries" : "StringArrayFallback")}; selectedWorldIndex={snapshot.SelectedWorldIndex}; worlds={snapshot.Worlds.Count} [{FormatWorldSelectorSnapshot(snapshot.Worlds)}]; lobbyEntries={lobbyEntries.Count} [{FormatLobbySnapshot(lobbyEntries)}].");
     }
 
     private void LogCharacterListSnapshot(IReadOnlyList<string> characterNames, IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) {
@@ -424,6 +437,14 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         }
     }
 
+    private static T TryRead<T>(Func<T> read) where T : struct {
+        try {
+            return read();
+        } catch {
+            return default;
+        }
+    }
+
     private static string Preview(IReadOnlyList<string> values) =>
         string.Join(", ", values.Take(8));
 
@@ -432,6 +453,18 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             return "<empty>";
 
         return string.Join("; ", entries.Select(FormatLobbyEntry));
+    }
+
+    private static string FormatWorldSelectorSnapshot(IReadOnlyList<AutoLoginWorldEntry> entries) {
+        if (entries.Count == 0)
+            return "<empty>";
+
+        return string.Join("; ", entries.Take(16).Select(FormatWorldSelectorEntry));
+    }
+
+    private static string FormatWorldSelectorEntry(AutoLoginWorldEntry entry) {
+        var countText = entry.CharacterCount == null ? "unknown" : entry.CharacterCount.ToString();
+        return $"idx={entry.SelectorIndex} id={entry.WorldId} name=\"{LogValue(entry.Name)}\" count={countText}";
     }
 
     private static string FormatLobbyEntry(AutoLoginLobbyEntry entry, int index) {
@@ -471,7 +504,8 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
     }
 
     private static bool SelectWorld(string worldName, out int index) {
-        index = WorldNames.FindIndex(i => i.Equals(worldName, StringComparison.InvariantCultureIgnoreCase));
+        var entry = ReadWorldSelectorSnapshot().Worlds.FirstOrDefault(i => i.Name.Equals(worldName, StringComparison.InvariantCultureIgnoreCase));
+        index = entry.Name == null ? -1 : entry.SelectorIndex;
         if (index < 0)
             return false;
 
@@ -540,6 +574,17 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         return true;
     }
 
+    private static WorldSelectorSnapshot ReadWorldSelectorSnapshot() {
+        var addonWorldEntries = ReadWorldSelectorEntries();
+        if (addonWorldEntries.Count > 0)
+            return new WorldSelectorSnapshot(addonWorldEntries, true, SelectedWorldIndex);
+
+        var fallbackEntries = WorldNames
+            .Select((world, index) => new AutoLoginWorldEntry(world, 0, index, null))
+            .ToList();
+        return new WorldSelectorSnapshot(fallbackEntries, false, SelectedWorldIndex);
+    }
+
     private static List<string> WorldNames {
         get {
             var result = new List<string>();
@@ -551,6 +596,29 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             }
             return result;
         }
+    }
+
+    private static List<AutoLoginWorldEntry> ReadWorldSelectorEntries() {
+        if (!GameDialogManager.IsAddonOpen("_CharaSelectWorldServer"))
+            return [];
+
+        var addonAddress = DalamudApi.GameGui.GetAddonByName("_CharaSelectWorldServer", 1).Address;
+        if (addonAddress == 0)
+            return [];
+
+        var addon = (AddonCharaSelectWorldServer*)addonAddress;
+        var entries = addon->WorldEntries;
+        var result = new List<AutoLoginWorldEntry>((int)entries.Count);
+        for (var i = 0; i < entries.Count; i++) {
+            var entry = entries[i];
+            var name = entry.DisplayName.ToString();
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            result.Add(new AutoLoginWorldEntry(name, entry.WorldId, i, checked((int)entry.CharacterCount)));
+        }
+
+        return result;
     }
 
     private static List<string> CharacterNames {
@@ -601,12 +669,51 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         }
     }
 
+    private static int SelectedWorldIndex {
+        get {
+            var numberArray = NumberArrays[2];
+            return numberArray == null ? -1 : numberArray->IntArray[167];
+        }
+    }
+
     private static string ReadStringArray(int arrayIndex, int stringIndex) {
         var stringArray = StringArrays[arrayIndex];
         if (stringArray == null || stringIndex < 0 || stringIndex >= stringArray->Size)
             return string.Empty;
 
         return (*(CStringPointer*)((byte*)stringArray->StringArray + stringIndex * (nint)Unsafe.SizeOf<CStringPointer>())).ToString();
+    }
+
+    private static bool IsTitleMenuReadyForAutoLogin() {
+        if (DalamudApi.ClientState.IsLoggedIn || DalamudApi.Condition.Any())
+            return false;
+
+        if (GameDialogManager.IsAddonOpen("TitleDCWorldMap") || GameDialogManager.IsAddonOpen("TitleConnect"))
+            return false;
+
+        var titleAddress = DalamudApi.GameGui.GetAddonByName("_TitleMenu", 1).Address;
+        if (titleAddress == 0)
+            return false;
+
+        var title = (AtkUnitBase*)titleAddress;
+        return title->IsVisible
+               && title->IsReady
+               && title->UldManager.NodeListCount > 3
+               && title->UldManager.NodeList[3] != null
+               && title->UldManager.NodeList[3]->Color.A == 0xFF;
+    }
+
+    private static List<string> GetCurrentLobbyWorlds(IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) {
+        var result = new List<string>();
+        foreach (var entry in lobbyEntries) {
+            if (string.IsNullOrWhiteSpace(entry.CurrentWorldName) ||
+                result.Contains(entry.CurrentWorldName, StringComparer.InvariantCultureIgnoreCase))
+                continue;
+
+            result.Add(entry.CurrentWorldName);
+        }
+
+        return result;
     }
 
     public void Dispose() {

--- a/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
@@ -41,6 +41,10 @@ public readonly record struct AutoLoginLobbyEntry(
     string RawJson,
     string ClientSelectWorldName);
 
+public readonly record struct AutoLoginWorldEntry(string Name, ushort WorldId, int SelectorIndex, int? CharacterCount);
+
+public readonly record struct AutoLoginWorldQueueResult(List<string> Worlds, List<string> Diagnostics);
+
 public readonly record struct AutoLoginTarget(string CharacterName, string WorldName);
 
 public static class AutoLoginPlanner {
@@ -59,22 +63,67 @@ public static class AutoLoginPlanner {
     public static List<string> BuildWorldQueue(
         IReadOnlyList<AutoLoginCandidate> candidates,
         IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
-        IReadOnlyList<string> visibleWorlds) {
+        IReadOnlyList<AutoLoginWorldEntry> visibleWorlds) =>
+        BuildWorldQueueWithDiagnostics(candidates, lobbyEntries, visibleWorlds).Worlds;
+
+    public static List<string> BuildWorldQueue(
+        IReadOnlyList<AutoLoginCandidate> candidates,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
+        IReadOnlyList<string> visibleWorlds) =>
+        BuildWorldQueue(
+            candidates,
+            lobbyEntries,
+            visibleWorlds.Select((world, index) => new AutoLoginWorldEntry(world, 0, index, null)).ToList());
+
+    public static AutoLoginWorldQueueResult BuildWorldQueueWithDiagnostics(
+        IReadOnlyList<AutoLoginCandidate> candidates,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
+        IReadOnlyList<AutoLoginWorldEntry> visibleWorlds,
+        IReadOnlyCollection<string>? fallbackWorldsToSkip = null) {
         var worldQueue = new List<string>();
-        var visibleWorldSet = visibleWorlds.ToHashSet(StringComparer.InvariantCultureIgnoreCase);
+        var diagnostics = new List<string>();
+        var visibleWorldMap = BuildVisibleWorldMap(visibleWorlds);
+        var fallbackWorldSkipSet = BuildWorldSet(fallbackWorldsToSkip);
 
         foreach (var candidate in candidates) {
             var entry = FindCandidateEntry(candidate, lobbyEntries);
-            if (entry == null)
+            if (entry == null) {
+                diagnostics.Add($"No lobby current-world entry for {FormatCandidate(candidate)}.");
                 continue;
+            }
 
-            AddWorld(worldQueue, visibleWorldSet, entry.Value.CurrentWorldName);
+            AddWorld(
+                worldQueue,
+                diagnostics,
+                visibleWorldMap,
+                entry.Value.CurrentWorldName,
+                $"lobby current world for {FormatCandidate(candidate)}");
         }
 
-        foreach (var world in visibleWorlds)
-            AddWorld(worldQueue, visibleWorldSet, world);
+        foreach (var candidate in candidates) {
+            AddWorld(
+                worldQueue,
+                diagnostics,
+                visibleWorldMap,
+                candidate.HomeWorldName,
+                $"configured home world for {FormatCandidate(candidate)}");
+        }
 
-        return worldQueue;
+        foreach (var world in visibleWorlds) {
+            if (fallbackWorldSkipSet.Contains(world.Name)) {
+                diagnostics.Add($"Skipped visible fallback '{world.Name}' at selector index {world.SelectorIndex}: already loaded as the current lobby world.");
+                continue;
+            }
+
+            AddWorld(
+                worldQueue,
+                diagnostics,
+                visibleWorldMap,
+                world.Name,
+                "visible fallback");
+        }
+
+        return new AutoLoginWorldQueueResult(worldQueue, diagnostics);
     }
 
     public static bool TryResolveDirectCharacterListTarget(
@@ -167,11 +216,64 @@ public static class AutoLoginPlanner {
         return null;
     }
 
-    private static void AddWorld(List<string> worldQueue, HashSet<string> visibleWorldSet, string worldName) {
-        if (string.IsNullOrWhiteSpace(worldName) || !visibleWorldSet.Contains(worldName))
-            return;
+    private static Dictionary<string, AutoLoginWorldEntry> BuildVisibleWorldMap(IReadOnlyList<AutoLoginWorldEntry> visibleWorlds) {
+        var result = new Dictionary<string, AutoLoginWorldEntry>(StringComparer.InvariantCultureIgnoreCase);
+        foreach (var world in visibleWorlds) {
+            if (string.IsNullOrWhiteSpace(world.Name) || result.ContainsKey(world.Name))
+                continue;
 
-        if (!worldQueue.Contains(worldName, StringComparer.InvariantCultureIgnoreCase))
-            worldQueue.Add(worldName);
+            result.Add(world.Name, world);
+        }
+
+        return result;
     }
+
+    private static HashSet<string> BuildWorldSet(IReadOnlyCollection<string>? worlds) {
+        var result = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+        if (worlds == null)
+            return result;
+
+        foreach (var world in worlds) {
+            if (!string.IsNullOrWhiteSpace(world))
+                result.Add(world);
+        }
+
+        return result;
+    }
+
+    private static void AddWorld(
+        List<string> worldQueue,
+        List<string> diagnostics,
+        IReadOnlyDictionary<string, AutoLoginWorldEntry> visibleWorldMap,
+        string worldName,
+        string source) {
+        if (string.IsNullOrWhiteSpace(worldName)) {
+            diagnostics.Add($"Skipped blank world from {source}.");
+            return;
+        }
+
+        if (!visibleWorldMap.TryGetValue(worldName, out var world)) {
+            diagnostics.Add($"Skipped {source} '{worldName}': not present in the world selector.");
+            return;
+        }
+
+        if (world.CharacterCount == 0) {
+            diagnostics.Add($"Skipped {source} '{world.Name}' at selector index {world.SelectorIndex}: selector reports 0 characters.");
+            return;
+        }
+
+        if (worldQueue.Contains(world.Name, StringComparer.InvariantCultureIgnoreCase)) {
+            diagnostics.Add($"Skipped {source} '{world.Name}' at selector index {world.SelectorIndex}: already queued.");
+            return;
+        }
+
+        worldQueue.Add(world.Name);
+        var countText = world.CharacterCount == null ? "an unknown number of" : world.CharacterCount.ToString();
+        diagnostics.Add($"Queued {source} '{world.Name}' at selector index {world.SelectorIndex} with {countText} characters.");
+    }
+
+    private static string FormatCandidate(AutoLoginCandidate candidate) =>
+        string.IsNullOrWhiteSpace(candidate.HomeWorldName)
+            ? $"{candidate.Name}({candidate.ContentId})"
+            : $"{candidate.Name}@{candidate.HomeWorldName}({candidate.ContentId})";
 }

--- a/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
+++ b/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
@@ -82,13 +82,112 @@ public class AutoLoginPlannerTests {
     }
 
     [Fact]
-    public void BuildWorldQueue_DoesNotUseConfiguredHomeWorldForSelection() {
+    public void BuildWorldQueue_UsesVisibleConfiguredHomeWorldBeforeFallback() {
         var queue = AutoLoginPlanner.BuildWorldQueue(
             [new AutoLoginCandidate(42, "Test Character", "Halicarnassus")],
             [],
             ["Diabolos", "Halicarnassus"]);
 
+        Assert.Equal(["Halicarnassus", "Diabolos"], queue);
+    }
+
+    [Fact]
+    public void BuildWorldQueue_UsesLobbyCurrentWorldBeforeConfiguredHomeWorld() {
+        var queue = AutoLoginPlanner.BuildWorldQueue(
+            [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
+            [LobbyEntry(42, "Test Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos")],
+            [
+                World("Diabolos", characterCount: 1),
+                World("Halicarnassus", characterCount: 1),
+                World("Cuchulainn", characterCount: 1),
+            ]);
+
+        Assert.Equal(["Halicarnassus", "Diabolos", "Cuchulainn"], queue);
+    }
+
+    [Fact]
+    public void BuildWorldQueue_SkipsConfiguredHomeWorldWhenSelectorCountIsZero() {
+        var queue = AutoLoginPlanner.BuildWorldQueue(
+            [new AutoLoginCandidate(42, "Test Character", "Halicarnassus")],
+            [],
+            [
+                World("Diabolos", characterCount: 1),
+                World("Halicarnassus", characterCount: 0),
+            ]);
+
+        Assert.Equal(["Diabolos"], queue);
+    }
+
+    [Fact]
+    public void BuildWorldQueue_SkipsZeroCountFallbackWorlds() {
+        var queue = AutoLoginPlanner.BuildWorldQueue(
+            [new AutoLoginCandidate(42, "Test Character", "Golem")],
+            [],
+            [
+                World("Diabolos", characterCount: 0),
+                World("Halicarnassus", characterCount: 2),
+            ]);
+
+        Assert.Equal(["Halicarnassus"], queue);
+    }
+
+    [Fact]
+    public void BuildWorldQueue_DoesNotSkipFallbackWorldsWithUnknownCounts() {
+        var queue = AutoLoginPlanner.BuildWorldQueue(
+            [new AutoLoginCandidate(42, "Test Character", "Golem")],
+            [],
+            [
+                World("Diabolos", characterCount: null),
+                World("Halicarnassus", characterCount: null),
+            ]);
+
         Assert.Equal(["Diabolos", "Halicarnassus"], queue);
+    }
+
+    [Fact]
+    public void BuildWorldQueueWithDiagnostics_ReportsHomeShortcutAndZeroCountSkips() {
+        var result = AutoLoginPlanner.BuildWorldQueueWithDiagnostics(
+            [new AutoLoginCandidate(42, "Test Character", "Halicarnassus")],
+            [],
+            [
+                World("Diabolos", characterCount: 1),
+                World("Halicarnassus", characterCount: 0),
+            ]);
+
+        Assert.Equal(["Diabolos"], result.Worlds);
+        Assert.Contains(result.Diagnostics, i => i.Contains("configured home world", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Diagnostics, i => i.Contains("0 characters", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildWorldQueueWithDiagnostics_SkipsCurrentLobbyWorldFromFallbackWhenNoCandidateMatches() {
+        var result = AutoLoginPlanner.BuildWorldQueueWithDiagnostics(
+            [new AutoLoginCandidate(42, "Test Character", "Golem")],
+            [LobbyEntry(100, "Other Character", currentWorld: "Goblin", homeWorld: "Golem")],
+            [
+                World("Diabolos", characterCount: null),
+                World("Goblin", characterCount: null),
+                World("Mateus", characterCount: null),
+            ],
+            ["Goblin"]);
+
+        Assert.Equal(["Diabolos", "Mateus"], result.Worlds);
+        Assert.Contains(result.Diagnostics, i => i.Contains("already loaded as the current lobby world", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildWorldQueueWithDiagnostics_KeepsCurrentLobbyWorldWhenMatchingCandidateQueuedIt() {
+        var result = AutoLoginPlanner.BuildWorldQueueWithDiagnostics(
+            [new AutoLoginCandidate(42, "Test Character", "Golem")],
+            [LobbyEntry(42, "Test Character", currentWorld: "Goblin", homeWorld: "Golem")],
+            [
+                World("Goblin", characterCount: null),
+                World("Diabolos", characterCount: null),
+            ],
+            ["Goblin"]);
+
+        Assert.Equal(["Goblin", "Diabolos"], result.Worlds);
+        Assert.Contains(result.Diagnostics, i => i.Contains("lobby current world", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -228,4 +327,7 @@ public class AutoLoginPlannerTests {
             0,
             string.Empty,
             currentWorld);
+
+    private static AutoLoginWorldEntry World(string name, int? characterCount) =>
+        new(name, 0, 0, characterCount);
 }


### PR DESCRIPTION
Attempted to pull other information from FFXIVClientStructs but there isn't more available that can be used to directly observe actual character world locations.