### PR TITLE
Add multi computer formation execution (using chat sync)

### DIFF
--- a/MasterOfPuppets/Commands/PluginCommandManager.cs
+++ b/MasterOfPuppets/Commands/PluginCommandManager.cs
@@ -8,6 +8,7 @@ using Dalamud.Game.Command;
 using Dalamud.Interface.ImGuiNotification;
 
 using MasterOfPuppets.Camera;
+using MasterOfPuppets.Formations;
 using MasterOfPuppets.Movement;
 using MasterOfPuppets.Util;
 
@@ -440,15 +441,14 @@ public class PluginCommandManager : IDisposable {
                             Plugin.Ui.FormationWindow.Toggle();
                             return;
                         }
-                        var useTargetAnchor = false;
-                        if (parsedArgs.Count >= 3) {
-                            if (!parsedArgs[2].Equals("target", StringComparison.OrdinalIgnoreCase)) {
-                                DalamudApi.ShowNotification("Invalid formation argument. Use: /mop formation \"Name\" [target]", NotificationType.Error, 5000);
-                                return;
-                            }
-                            useTargetAnchor = true;
+                        var anchor = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+                            parsedArgs.Skip(2),
+                            FormationAnchorReference.Self);
+                        if (anchor.InvalidArgument != null) {
+                            DalamudApi.ShowNotification($"Invalid formation argument: {anchor.InvalidArgument}", NotificationType.Error, 5000);
+                            return;
                         }
-                        Plugin.IpcProvider.ExecuteFormation(parsedArgs[1], useTargetAnchor);
+                        Plugin.IpcProvider.ExecuteFormation(parsedArgs[1], anchor.Anchor);
                     }
                     break;
                 case "layout": {

--- a/MasterOfPuppets/Commands/PluginCommandManager.cs
+++ b/MasterOfPuppets/Commands/PluginCommandManager.cs
@@ -448,7 +448,7 @@ public class PluginCommandManager : IDisposable {
                             DalamudApi.ShowNotification($"Invalid formation argument: {anchor.InvalidArgument}", NotificationType.Error, 5000);
                             return;
                         }
-                        Plugin.IpcProvider.ExecuteFormation(parsedArgs[1], anchor.Anchor);
+                        Plugin.IpcProvider.ExecuteFormation(parsedArgs[1], anchor.Anchor, anchor.MovementMode);
                     }
                     break;
                 case "layout": {

--- a/MasterOfPuppets/Formations/FormationAnchorReference.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorReference.cs
@@ -26,16 +26,16 @@ public sealed record FormationAnchorReference(FormationAnchorKind Kind, string? 
 
 public sealed record FormationAnchorParseResult(
     FormationAnchorReference Anchor,
-    MovementArrivalMode ArrivalMode,
+    SimpleMovementMode MovementMode,
     string? InvalidArgument);
 
 public static class FormationAnchorArgumentParser {
     public static FormationAnchorParseResult ParseAnchorAndArrival(
         IEnumerable<string> arguments,
         FormationAnchorReference? defaultAnchor = null,
-        MovementArrivalMode defaultArrivalMode = MovementArrivalMode.Continuous) {
+        SimpleMovementMode defaultMovementMode = SimpleMovementMode.Continuous) {
         var anchor = defaultAnchor ?? FormationAnchorReference.Default;
-        var arrivalMode = defaultArrivalMode;
+        var movementMode = defaultMovementMode;
         string? invalidArgument = null;
 
         foreach (var rawArgument in arguments) {
@@ -43,13 +43,13 @@ public static class FormationAnchorArgumentParser {
             if (argument.Length == 0)
                 continue;
 
-            if (argument.Equals("precise", StringComparison.OrdinalIgnoreCase)) {
-                arrivalMode = MovementArrivalMode.Precise;
+            if (SimpleInputMovement.TryParseMode(argument, out var parsedMovementMode)) {
+                movementMode = parsedMovementMode;
                 continue;
             }
 
-            if (argument.Equals("continuous", StringComparison.OrdinalIgnoreCase)) {
-                arrivalMode = MovementArrivalMode.Continuous;
+            if (argument.Equals("hybrid", StringComparison.OrdinalIgnoreCase)) {
+                invalidArgument ??= argument;
                 continue;
             }
 
@@ -72,7 +72,7 @@ public static class FormationAnchorArgumentParser {
             }
         }
 
-        return new FormationAnchorParseResult(anchor, arrivalMode, invalidArgument);
+        return new FormationAnchorParseResult(anchor, movementMode, invalidArgument);
     }
 
     public static string FormatForMacro(FormationAnchorReference anchor) =>

--- a/MasterOfPuppets/Formations/FormationAnchorReference.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorReference.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MasterOfPuppets.Movement;
+
+namespace MasterOfPuppets.Formations;
+
+public enum FormationAnchorKind {
+    Default,
+    Self,
+    Target,
+    Named,
+}
+
+public sealed record FormationAnchorReference(FormationAnchorKind Kind, string? Name = null) {
+    public static readonly FormationAnchorReference Default = new(FormationAnchorKind.Default);
+    public static readonly FormationAnchorReference Self = new(FormationAnchorKind.Self);
+    public static readonly FormationAnchorReference Target = new(FormationAnchorKind.Target);
+
+    public static FormationAnchorReference Named(string name) => new(FormationAnchorKind.Named, name);
+
+    public override string ToString() =>
+        Kind == FormationAnchorKind.Named ? $"\"{Name}\"" : Kind.ToString().ToLowerInvariant();
+}
+
+public sealed record FormationAnchorParseResult(
+    FormationAnchorReference Anchor,
+    MovementArrivalMode ArrivalMode,
+    string? InvalidArgument);
+
+public static class FormationAnchorArgumentParser {
+    public static FormationAnchorParseResult ParseAnchorAndArrival(
+        IEnumerable<string> arguments,
+        FormationAnchorReference? defaultAnchor = null,
+        MovementArrivalMode defaultArrivalMode = MovementArrivalMode.Continuous) {
+        var anchor = defaultAnchor ?? FormationAnchorReference.Default;
+        var arrivalMode = defaultArrivalMode;
+        string? invalidArgument = null;
+
+        foreach (var rawArgument in arguments) {
+            var argument = rawArgument.Trim();
+            if (argument.Length == 0)
+                continue;
+
+            if (argument.Equals("precise", StringComparison.OrdinalIgnoreCase)) {
+                arrivalMode = MovementArrivalMode.Precise;
+                continue;
+            }
+
+            if (argument.Equals("continuous", StringComparison.OrdinalIgnoreCase)) {
+                arrivalMode = MovementArrivalMode.Continuous;
+                continue;
+            }
+
+            var candidate = argument.StartsWith("anchor=", StringComparison.OrdinalIgnoreCase)
+                ? argument["anchor=".Length..].Trim()
+                : argument;
+            if (candidate.Length == 0) {
+                invalidArgument ??= argument;
+                continue;
+            }
+
+            if (candidate.Equals("default", StringComparison.OrdinalIgnoreCase)) {
+                anchor = FormationAnchorReference.Default;
+            } else if (candidate.Equals("self", StringComparison.OrdinalIgnoreCase)) {
+                anchor = FormationAnchorReference.Self;
+            } else if (candidate.Equals("target", StringComparison.OrdinalIgnoreCase)) {
+                anchor = FormationAnchorReference.Target;
+            } else {
+                anchor = FormationAnchorReference.Named(candidate);
+            }
+        }
+
+        return new FormationAnchorParseResult(anchor, arrivalMode, invalidArgument);
+    }
+
+    public static string FormatForMacro(FormationAnchorReference anchor) =>
+        anchor.Kind switch {
+            FormationAnchorKind.Default => string.Empty,
+            FormationAnchorKind.Self => "self",
+            FormationAnchorKind.Target => "target",
+            FormationAnchorKind.Named => $"\"{MasterOfPuppets.Util.ArgumentParser.EscapeQuotedArgument(anchor.Name ?? string.Empty)}\"",
+            _ => string.Empty,
+        };
+}

--- a/MasterOfPuppets/Formations/FormationAnchorResolver.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorResolver.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Linq;
+using System.Numerics;
+
+using Dalamud.Game.ClientState.Objects.Enums;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.Types;
+
+namespace MasterOfPuppets.Formations;
+
+public sealed record FormationResolvedAnchor(Vector3 Position, float Rotation, ulong? ContentId = null, string Name = "");
+
+public static class FormationAnchorResolver {
+    public static bool TryResolve(
+        Plugin plugin,
+        Formation formation,
+        FormationAnchorReference anchor,
+        out FormationResolvedAnchor resolved,
+        out string failureReason) {
+        resolved = new FormationResolvedAnchor(default, default);
+        failureReason = string.Empty;
+
+        var player = DalamudApi.ObjectTable.LocalPlayer;
+        if (player == null) {
+            failureReason = "local player is unavailable";
+            return false;
+        }
+
+        switch (anchor.Kind) {
+            case FormationAnchorKind.Default:
+                return TryResolvePointOneAnchor(plugin, formation, out resolved, out failureReason);
+            case FormationAnchorKind.Self:
+                resolved = new FormationResolvedAnchor(
+                    player.Position,
+                    player.Rotation,
+                    DalamudApi.PlayerState.ContentId,
+                    GetLocalPlayerNameWorld());
+                return true;
+            case FormationAnchorKind.Target:
+                if (player.TargetObject == null) {
+                    failureReason = "no target selected";
+                    return false;
+                }
+
+                resolved = new FormationResolvedAnchor(
+                    player.TargetObject.Position,
+                    player.TargetObject.Rotation,
+                    null,
+                    player.TargetObject.Name.TextValue);
+                return true;
+            case FormationAnchorKind.Named:
+                return TryResolveNamed(anchor.Name ?? string.Empty, out resolved, out failureReason);
+            default:
+                failureReason = $"unsupported anchor kind {anchor.Kind}";
+                return false;
+        }
+    }
+
+    public static bool TryResolveNamed(
+        string objectName,
+        out FormationResolvedAnchor resolved,
+        out string failureReason) {
+        resolved = new FormationResolvedAnchor(default, default);
+        failureReason = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(objectName)) {
+            failureReason = "anchor name is empty";
+            return false;
+        }
+
+        var candidates = DalamudApi.ObjectTable
+            .Where(actor => actor != null && actor.Name.TextValue.Length > 0)
+            .Select(actor => {
+                var name = actor!.Name.TextValue;
+                var fullName = name;
+                if (actor.ObjectKind == ObjectKind.Pc &&
+                    actor is IPlayerCharacter player &&
+                    player.HomeWorld.ValueNullable is { } world)
+                    fullName = $"{name}@{world.Name}";
+
+                return new AnchorCandidate(actor, name, fullName);
+            })
+            .ToList();
+
+        AnchorCandidate? match =
+            candidates.FirstOrDefault(candidate => candidate.FullName.Equals(objectName, StringComparison.InvariantCultureIgnoreCase))
+            ?? candidates.FirstOrDefault(candidate => candidate.Name.Equals(objectName, StringComparison.InvariantCultureIgnoreCase))
+            ?? candidates.FirstOrDefault(candidate => candidate.FullName.Contains(objectName, StringComparison.InvariantCultureIgnoreCase))
+            ?? candidates.FirstOrDefault(candidate => candidate.Name.Contains(objectName, StringComparison.InvariantCultureIgnoreCase));
+
+        if (match == null) {
+            failureReason = $"anchor not visible: \"{objectName}\"";
+            return false;
+        }
+
+        resolved = new FormationResolvedAnchor(
+            match.Actor.Position,
+            match.Actor.Rotation,
+            null,
+            match.FullName);
+        return true;
+    }
+
+    private static bool TryResolvePointOneAnchor(
+        Plugin plugin,
+        Formation formation,
+        out FormationResolvedAnchor resolved,
+        out string failureReason) {
+        resolved = new FormationResolvedAnchor(default, default);
+        if (!FormationPointMovement.TryGetPointOneAnchorCid(formation, plugin.Config.CidsGroups, out var anchorCid, out failureReason))
+            return false;
+
+        if (anchorCid == DalamudApi.PlayerState.ContentId) {
+            var player = DalamudApi.ObjectTable.LocalPlayer;
+            if (player == null) {
+                failureReason = "local point-1 anchor is unavailable";
+                return false;
+            }
+
+            resolved = new FormationResolvedAnchor(player.Position, player.Rotation, anchorCid, GetLocalPlayerNameWorld());
+            return true;
+        }
+
+        var configuredName = plugin.Config.Characters.FirstOrDefault(character => character.Cid == anchorCid)?.Name;
+        if (string.IsNullOrWhiteSpace(configuredName)) {
+            failureReason = $"point 1 character {anchorCid} is not configured";
+            return false;
+        }
+
+        if (TryResolveNamed(configuredName, out resolved, out failureReason)) {
+            resolved = resolved with { ContentId = anchorCid };
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string GetLocalPlayerNameWorld() {
+        var name = DalamudApi.PlayerState.CharacterName;
+        if (string.IsNullOrWhiteSpace(name))
+            return string.Empty;
+
+        var world = DalamudApi.PlayerState.HomeWorld.Value.Name.ToString();
+        return string.IsNullOrWhiteSpace(world) ? name : $"{name}@{world}";
+    }
+
+    private sealed record AnchorCandidate(IGameObject Actor, string Name, string FullName);
+}

--- a/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
+++ b/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
@@ -12,7 +12,7 @@ public static class FormationLocalMovementExecutor {
         string formationName,
         int destinationPointIndex,
         FormationAnchorReference anchor,
-        MovementArrivalMode arrivalMode,
+        SimpleMovementMode movementMode,
         string logPrefix = "mopformationgoto") {
         if (!TryGetFormation(plugin, formationName, logPrefix, out var formation))
             return false;
@@ -28,7 +28,7 @@ public static class FormationLocalMovementExecutor {
             destinationPointIndex,
             resolvedAnchor.Position,
             resolvedAnchor.Rotation,
-            arrivalMode,
+            movementMode,
             logPrefix);
     }
 
@@ -36,7 +36,7 @@ public static class FormationLocalMovementExecutor {
         Plugin plugin,
         string formationName,
         FormationAnchorReference anchor,
-        MovementArrivalMode arrivalMode) {
+        SimpleMovementMode movementMode) {
         const string logPrefix = "mopformation";
         if (!TryGetFormation(plugin, formationName, logPrefix, out var formation))
             return false;
@@ -64,7 +64,7 @@ public static class FormationLocalMovementExecutor {
             destinationPointIndex,
             resolvedAnchor.Position,
             resolvedAnchor.Rotation,
-            arrivalMode,
+            movementMode,
             logPrefix);
     }
 
@@ -74,7 +74,7 @@ public static class FormationLocalMovementExecutor {
         int destinationPointIndex,
         Vector3 anchorWorldPosition,
         float anchorWorldRotation,
-        MovementArrivalMode arrivalMode,
+        SimpleMovementMode movementMode,
         string logPrefix) {
         var move = FormationPointMovement.BuildPointOneAnchoredWorldMove(
             formation,
@@ -86,8 +86,8 @@ public static class FormationLocalMovementExecutor {
             return false;
         }
 
-        MoveToComputed(plugin, move.Value.Position, move.Value.Rotation, arrivalMode);
-        DalamudApi.PluginLog.Debug($"[{logPrefix}] formation=\"{formation.Name}\" point={destinationPointIndex + 1} arrivalMode={arrivalMode}");
+        MoveToComputed(plugin, move.Value.Position, move.Value.Rotation, movementMode);
+        DalamudApi.PluginLog.Debug($"[{logPrefix}] formation=\"{formation.Name}\" point={destinationPointIndex + 1} movementMode={movementMode}");
         return true;
     }
 
@@ -95,12 +95,12 @@ public static class FormationLocalMovementExecutor {
         Plugin plugin,
         Vector3 position,
         float rotation,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous) {
+        SimpleMovementMode movementMode = SimpleMovementMode.Continuous) {
         plugin.SimpleInputMovement.MoveTo(
             position,
             precision: plugin.Config.FormationMovePrecision,
             faceDirection: rotation,
-            arrivalMode: arrivalMode,
+            movementMode: movementMode,
             stopOnStuck: plugin.Config.StopOnStuck,
             stuckTolerance: plugin.Config.StuckTolerance,
             stuckTimeoutMs: plugin.Config.StuckTimeoutMs);

--- a/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
+++ b/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Linq;
+using System.Numerics;
+
+using MasterOfPuppets.Movement;
+
+namespace MasterOfPuppets.Formations;
+
+public static class FormationLocalMovementExecutor {
+    public static bool ExecuteFormationGoto(
+        Plugin plugin,
+        string formationName,
+        int destinationPointIndex,
+        FormationAnchorReference anchor,
+        MovementArrivalMode arrivalMode,
+        string logPrefix = "mopformationgoto") {
+        if (!TryGetFormation(plugin, formationName, logPrefix, out var formation))
+            return false;
+
+        if (!FormationAnchorResolver.TryResolve(plugin, formation, anchor, out var resolvedAnchor, out var anchorFailure)) {
+            DalamudApi.PluginLog.Warning($"[{logPrefix}] {anchorFailure}");
+            return false;
+        }
+
+        return ExecutePointOneAnchoredMove(
+            plugin,
+            formation,
+            destinationPointIndex,
+            resolvedAnchor.Position,
+            resolvedAnchor.Rotation,
+            arrivalMode,
+            logPrefix);
+    }
+
+    public static bool ExecuteChatSyncedFormation(
+        Plugin plugin,
+        string formationName,
+        FormationAnchorReference anchor,
+        MovementArrivalMode arrivalMode) {
+        const string logPrefix = "mopformation";
+        if (!TryGetFormation(plugin, formationName, logPrefix, out var formation))
+            return false;
+
+        var localCid = DalamudApi.PlayerState.ContentId;
+        var destinationPointIndex = FormationExecution.GetAssignedPointIndex(formation, localCid, plugin.Config.CidsGroups);
+        if (destinationPointIndex < 0) {
+            DalamudApi.PluginLog.Debug($"[{logPrefix}] local character is not assigned to formation \"{formationName}\"");
+            return false;
+        }
+
+        if (anchor.Kind == FormationAnchorKind.Default && destinationPointIndex == FormationPointMovement.AnchorPointIndex) {
+            DalamudApi.PluginLog.Debug($"[{logPrefix}] local character is point 1 anchor for formation \"{formationName}\"; no movement needed");
+            return true;
+        }
+
+        if (!FormationAnchorResolver.TryResolve(plugin, formation, anchor, out var resolvedAnchor, out var anchorFailure)) {
+            DalamudApi.PluginLog.Warning($"[{logPrefix}] {anchorFailure}");
+            return false;
+        }
+
+        return ExecutePointOneAnchoredMove(
+            plugin,
+            formation,
+            destinationPointIndex,
+            resolvedAnchor.Position,
+            resolvedAnchor.Rotation,
+            arrivalMode,
+            logPrefix);
+    }
+
+    public static bool ExecutePointOneAnchoredMove(
+        Plugin plugin,
+        Formation formation,
+        int destinationPointIndex,
+        Vector3 anchorWorldPosition,
+        float anchorWorldRotation,
+        MovementArrivalMode arrivalMode,
+        string logPrefix) {
+        var move = FormationPointMovement.BuildPointOneAnchoredWorldMove(
+            formation,
+            destinationPointIndex,
+            anchorWorldPosition,
+            anchorWorldRotation);
+        if (move == null) {
+            DalamudApi.PluginLog.Warning($"[{logPrefix}] point {destinationPointIndex + 1} is not valid for formation \"{formation.Name}\"");
+            return false;
+        }
+
+        MoveToComputed(plugin, move.Value.Position, move.Value.Rotation, arrivalMode);
+        DalamudApi.PluginLog.Debug($"[{logPrefix}] formation=\"{formation.Name}\" point={destinationPointIndex + 1} arrivalMode={arrivalMode}");
+        return true;
+    }
+
+    public static void MoveToComputed(
+        Plugin plugin,
+        Vector3 position,
+        float rotation,
+        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous) {
+        plugin.SimpleInputMovement.MoveTo(
+            position,
+            precision: plugin.Config.FormationMovePrecision,
+            faceDirection: rotation,
+            arrivalMode: arrivalMode,
+            stopOnStuck: plugin.Config.StopOnStuck,
+            stuckTolerance: plugin.Config.StuckTolerance,
+            stuckTimeoutMs: plugin.Config.StuckTimeoutMs);
+    }
+
+    private static bool TryGetFormation(
+        Plugin plugin,
+        string formationName,
+        string logPrefix,
+        out Formation formation) {
+        formation = plugin.Config.Formations.FirstOrDefault(f =>
+            string.Equals(f.Name, formationName, System.StringComparison.OrdinalIgnoreCase))!;
+        if (formation != null)
+            return true;
+
+        DalamudApi.PluginLog.Warning($"[{logPrefix}] formation not found: \"{formationName}\"");
+        return false;
+    }
+}

--- a/MasterOfPuppets/Formations/FormationPointMovement.cs
+++ b/MasterOfPuppets/Formations/FormationPointMovement.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+using MasterOfPuppets.Extensions;
+
+namespace MasterOfPuppets.Formations;
+
+public static class FormationPointMovement {
+    public const int AnchorPointIndex = 0;
+
+    public static (Vector3 Position, float Rotation)? BuildPointOneAnchoredWorldMove(
+        Formation formation,
+        int destinationPointIndex,
+        Vector3 anchorWorldPosition,
+        float anchorWorldRotation) {
+        if (!formation.Points.IndexExists(AnchorPointIndex) || !formation.Points.IndexExists(destinationPointIndex))
+            return null;
+
+        return FormationMath.GetMopRelativeWorld(
+            formation.Points[AnchorPointIndex],
+            formation.Points[destinationPointIndex],
+            anchorWorldPosition,
+            anchorWorldRotation);
+    }
+
+    public static bool TryGetPointOneAnchorCid(
+        Formation formation,
+        IReadOnlyList<CidGroup>? groups,
+        out ulong contentId,
+        out string failureReason) {
+        contentId = default;
+        failureReason = string.Empty;
+
+        if (!formation.Points.IndexExists(AnchorPointIndex)) {
+            failureReason = "formation does not have point 1";
+            return false;
+        }
+
+        var cids = formation.Points[AnchorPointIndex].GetEffectiveCids(groups).ToList();
+        if (cids.Count != 1) {
+            failureReason = $"point 1 must have exactly one assigned character; found {cids.Count}";
+            return false;
+        }
+
+        contentId = cids[0];
+        return true;
+    }
+
+    public static (Vector3 Position, float Rotation)? BuildAssignedPointOneAnchoredWorldMove(
+        Formation formation,
+        ulong destinationContentId,
+        IReadOnlyList<CidGroup>? groups,
+        Vector3 anchorWorldPosition,
+        float anchorWorldRotation,
+        out int destinationPointIndex) {
+        destinationPointIndex = FormationExecution.GetAssignedPointIndex(formation, destinationContentId, groups);
+        return destinationPointIndex < 0
+            ? null
+            : BuildPointOneAnchoredWorldMove(formation, destinationPointIndex, anchorWorldPosition, anchorWorldRotation);
+    }
+}

--- a/MasterOfPuppets/Formations/FormationShareCode.cs
+++ b/MasterOfPuppets/Formations/FormationShareCode.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MasterOfPuppets.Extensions;
+
+namespace MasterOfPuppets.Formations;
+
+public static class FormationShareCode {
+    public const string Prefix = "MOPF1:";
+
+    public static string Export(Formation formation, bool includeAssignments) {
+        var clone = formation.Clone();
+        if (!includeAssignments) {
+            foreach (var point in clone.Points) {
+                point.Cids.Clear();
+                point.GroupIds.Clear();
+            }
+        }
+
+        return Prefix + clone.JsonSerialize().Compress();
+    }
+
+    public static bool TryImport(string code, out Formation formation, out string error) {
+        formation = new Formation();
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(code)) {
+            error = "Formation code is empty.";
+            return false;
+        }
+
+        var trimmed = code.Trim();
+        if (!trimmed.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)) {
+            error = $"Formation code must start with {Prefix}.";
+            return false;
+        }
+
+        try {
+            var json = trimmed[Prefix.Length..].Decompress();
+            var imported = json.JsonDeserialize<Formation>();
+            if (imported == null) {
+                error = "Formation code did not contain a formation.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(imported.Name))
+                imported.Name = "Imported Formation";
+            imported.Points ??= [];
+            foreach (var point in imported.Points) {
+                point.Cids ??= [];
+                point.GroupIds ??= [];
+            }
+
+            formation = imported;
+            return true;
+        } catch (Exception ex) {
+            error = $"Could not parse formation code: {ex.Message}";
+            return false;
+        }
+    }
+
+    public static string GetUniqueName(string requestedName, IEnumerable<Formation> existingFormations) {
+        var baseName = string.IsNullOrWhiteSpace(requestedName) ? "Imported Formation" : requestedName.Trim();
+        if (!existingFormations.Any(f => f.Name.Equals(baseName, StringComparison.OrdinalIgnoreCase)))
+            return baseName;
+
+        var index = 2;
+        while (existingFormations.Any(f => f.Name.Equals($"{baseName} ({index})", StringComparison.OrdinalIgnoreCase)))
+            index++;
+        return $"{baseName} ({index})";
+    }
+}

--- a/MasterOfPuppets/Game/ChatWatcher.cs
+++ b/MasterOfPuppets/Game/ChatWatcher.cs
@@ -192,7 +192,7 @@ internal class ChatWatcher : IDisposable {
                 Plugin,
                 args[0],
                 anchor.Anchor,
-                anchor.ArrivalMode));
+                anchor.MovementMode));
     }
 
     private static string SanitizeSenderName(string raw) {

--- a/MasterOfPuppets/Game/ChatWatcher.cs
+++ b/MasterOfPuppets/Game/ChatWatcher.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Dalamud.Game.Chat;
 using Dalamud.Game.Text;
 
+using MasterOfPuppets.Formations;
 using MasterOfPuppets.Util;
 
 namespace MasterOfPuppets;
@@ -48,6 +49,7 @@ internal class ChatWatcher : IDisposable {
             ["mopbr"] = HandleBroadcastCommandExecution,
             ["mopbrn"] = HandleBroadcastNotMeCommandExecution,
             ["mopbrc"] = HandleBroadcastCharacterCommandExecution,
+            ["mopformation"] = HandleFormationCommand,
         };
 
         DalamudApi.ChatGui.ChatMessage += OnChatMessage;
@@ -169,6 +171,28 @@ internal class ChatWatcher : IDisposable {
         if (!localPlayerName.Contains(characterName, StringComparison.InvariantCultureIgnoreCase)) return;
 
         Plugin.MacroHandler.EnqueueMacroActions("#mopbrc-inline-macro", actions: [textCommand], delayBetweenActions: 0);
+    }
+
+    private void HandleFormationCommand(string[] args, string senderName) {
+        if (args.Length < 1) {
+            DalamudApi.ChatGui.PrintError("Invalid command arguments expected 1 <formation name>");
+            return;
+        }
+
+        var anchor = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            args.Skip(1),
+            FormationAnchorReference.Default);
+        if (anchor.InvalidArgument != null) {
+            DalamudApi.ChatGui.PrintError($"Invalid command argument: {anchor.InvalidArgument}");
+            return;
+        }
+
+        _ = DalamudApi.Framework.RunOnFrameworkThread(() =>
+            FormationLocalMovementExecutor.ExecuteChatSyncedFormation(
+                Plugin,
+                args[0],
+                anchor.Anchor,
+                anchor.ArrivalMode));
     }
 
     private static string SanitizeSenderName(string raw) {

--- a/MasterOfPuppets/Game/Movement/ArrivePreciseMovementStrategy.cs
+++ b/MasterOfPuppets/Game/Movement/ArrivePreciseMovementStrategy.cs
@@ -1,0 +1,62 @@
+using System.Numerics;
+
+using MasterOfPuppets.Extensions;
+
+namespace MasterOfPuppets.Movement;
+
+internal sealed class ArrivePreciseMovementStrategy : ISimpleMovementStrategy {
+    private readonly ForwardInputMovementController _forwardInput;
+    private readonly NativeStop _nativeStop;
+    private bool _settling;
+    private int _settleFrames;
+
+    public ArrivePreciseMovementStrategy(ForwardInputMovementController forwardInput, NativeStop nativeStop) {
+        _forwardInput = forwardInput;
+        _nativeStop = nativeStop;
+    }
+
+    public string Name => "Precise";
+    public bool UsesNativeStopOnCompletion => true;
+
+    public void Start(SimpleMovementContext context) {
+        _settling = false;
+        _settleFrames = 0;
+    }
+
+    public SimpleMovementUpdateResult Update(SimpleMovementContext context, Vector3 playerPosition) {
+        var distance = playerPosition.Distance2D(context.Destination);
+        if (_settling) {
+            if (distance > context.Precision + SimpleInputMovement.SettleHysteresis) {
+                _settling = false;
+                _settleFrames = 0;
+            } else {
+                _forwardInput.Stop();
+                SimpleMovementWalkState.IsWalking = false;
+                _settleFrames++;
+                return _settleFrames >= SimpleInputMovement.SettleFrameCount
+                    ? SimpleMovementUpdateResult.Complete
+                    : SimpleMovementUpdateResult.Running;
+            }
+        }
+
+        if (distance <= context.Precision) {
+            _forwardInput.Stop();
+            SimpleMovementWalkState.IsWalking = false;
+            _nativeStop.Stop();
+            _settling = true;
+            _settleFrames = 0;
+            return SimpleMovementUpdateResult.Running;
+        }
+
+        GameFunctions.FaceDirection(context.Destination);
+        _forwardInput.MoveForward();
+        SimpleMovementWalkState.IsWalking = distance <= context.Precision + SimpleInputMovement.ArrivalWalkBuffer;
+        return SimpleMovementUpdateResult.Running;
+    }
+
+    public void Stop() {
+        _settling = false;
+        _settleFrames = 0;
+        _forwardInput.Stop();
+    }
+}

--- a/MasterOfPuppets/Game/Movement/ContinuousForwardMovementStrategy.cs
+++ b/MasterOfPuppets/Game/Movement/ContinuousForwardMovementStrategy.cs
@@ -1,0 +1,33 @@
+using System.Numerics;
+
+using MasterOfPuppets.Extensions;
+
+namespace MasterOfPuppets.Movement;
+
+internal sealed class ContinuousForwardMovementStrategy : ISimpleMovementStrategy {
+    private readonly ForwardInputMovementController _forwardInput;
+
+    public ContinuousForwardMovementStrategy(ForwardInputMovementController forwardInput) {
+        _forwardInput = forwardInput;
+    }
+
+    public string Name => "Continuous";
+    public bool UsesNativeStopOnCompletion => false;
+
+    public void Start(SimpleMovementContext context) {
+    }
+
+    public SimpleMovementUpdateResult Update(SimpleMovementContext context, Vector3 playerPosition) {
+        if (playerPosition.Distance2D(context.Destination) <= context.Precision)
+            return SimpleMovementUpdateResult.Complete;
+
+        GameFunctions.FaceDirection(context.Destination);
+        _forwardInput.MoveForward();
+        SimpleMovementWalkState.IsWalking = false;
+        return SimpleMovementUpdateResult.Running;
+    }
+
+    public void Stop() {
+        _forwardInput.Stop();
+    }
+}

--- a/MasterOfPuppets/Game/Movement/ContinuousForwardMovementStrategy.cs
+++ b/MasterOfPuppets/Game/Movement/ContinuousForwardMovementStrategy.cs
@@ -6,6 +6,8 @@ namespace MasterOfPuppets.Movement;
 
 internal sealed class ContinuousForwardMovementStrategy : ISimpleMovementStrategy {
     private readonly ForwardInputMovementController _forwardInput;
+    private float? _previousDistance;
+    private bool _hasApproachedDestination;
 
     public ContinuousForwardMovementStrategy(ForwardInputMovementController forwardInput) {
         _forwardInput = forwardInput;
@@ -15,10 +17,22 @@ internal sealed class ContinuousForwardMovementStrategy : ISimpleMovementStrateg
     public bool UsesNativeStopOnCompletion => false;
 
     public void Start(SimpleMovementContext context) {
+        _previousDistance = null;
+        _hasApproachedDestination = false;
     }
 
     public SimpleMovementUpdateResult Update(SimpleMovementContext context, Vector3 playerPosition) {
-        if (playerPosition.Distance2D(context.Destination) <= context.Precision)
+        var distance = playerPosition.Distance2D(context.Destination);
+        var progress = SimpleInputMovement.UpdateContinuousProgress(
+            distance,
+            context.Precision,
+            _previousDistance,
+            _hasApproachedDestination);
+
+        _previousDistance = distance;
+        _hasApproachedDestination = progress.HasApproached;
+
+        if (progress.Complete)
             return SimpleMovementUpdateResult.Complete;
 
         GameFunctions.FaceDirection(context.Destination);
@@ -28,6 +42,8 @@ internal sealed class ContinuousForwardMovementStrategy : ISimpleMovementStrateg
     }
 
     public void Stop() {
+        _previousDistance = null;
+        _hasApproachedDestination = false;
         _forwardInput.Stop();
     }
 }

--- a/MasterOfPuppets/Game/Movement/ForwardInputMovementController.cs
+++ b/MasterOfPuppets/Game/Movement/ForwardInputMovementController.cs
@@ -1,0 +1,50 @@
+using System;
+
+using Dalamud.Hooking;
+
+namespace MasterOfPuppets.Movement;
+
+internal unsafe sealed class ForwardInputMovementController : IDisposable {
+    private delegate byte PlayerMoveDelegate(nint a1, int direction);
+    private Hook<PlayerMoveDelegate>? _playerMoveHook;
+    private MovementDirection _direction;
+
+    public MovementDirection Direction {
+        get => _direction;
+        set {
+            _direction = value;
+            if (value == MovementDirection.None)
+                _playerMoveHook?.Disable();
+            else
+                _playerMoveHook?.Enable();
+        }
+    }
+
+    public ForwardInputMovementController() {
+        _playerMoveHook = DalamudApi.GameInteropProvider.HookFromSignature<PlayerMoveDelegate>(
+            "E8 ?? ?? ?? ?? 4C 63 4B 04",
+            PlayerMoveDetour);
+    }
+
+    public void Dispose() {
+        Direction = MovementDirection.None;
+        _playerMoveHook?.Disable();
+        _playerMoveHook?.Dispose();
+        _playerMoveHook = null;
+    }
+
+    public void MoveForward() {
+        Direction = MovementDirection.Forward;
+    }
+
+    public void Stop() {
+        Direction = MovementDirection.None;
+    }
+
+    private byte PlayerMoveDetour(nint a1, int dir) {
+        var original = _playerMoveHook!.Original(a1, dir);
+        return _direction != MovementDirection.None && dir == (int)_direction
+            ? (byte)1
+            : original;
+    }
+}

--- a/MasterOfPuppets/Game/Movement/ForwardPreciseMovementStrategy.cs
+++ b/MasterOfPuppets/Game/Movement/ForwardPreciseMovementStrategy.cs
@@ -1,0 +1,34 @@
+using System.Numerics;
+
+using MasterOfPuppets.Extensions;
+
+namespace MasterOfPuppets.Movement;
+
+internal sealed class ForwardPreciseMovementStrategy : ISimpleMovementStrategy {
+    private readonly ForwardInputMovementController _forwardInput;
+
+    public ForwardPreciseMovementStrategy(ForwardInputMovementController forwardInput) {
+        _forwardInput = forwardInput;
+    }
+
+    public string Name => "Forward";
+    public bool UsesNativeStopOnCompletion => true;
+
+    public void Start(SimpleMovementContext context) {
+    }
+
+    public SimpleMovementUpdateResult Update(SimpleMovementContext context, Vector3 playerPosition) {
+        var distance = playerPosition.Distance2D(context.Destination);
+        if (distance <= context.Precision)
+            return SimpleMovementUpdateResult.Complete;
+
+        GameFunctions.FaceDirection(context.Destination);
+        _forwardInput.MoveForward();
+        SimpleMovementWalkState.IsWalking = distance <= context.Precision + SimpleInputMovement.ArrivalWalkBuffer;
+        return SimpleMovementUpdateResult.Running;
+    }
+
+    public void Stop() {
+        _forwardInput.Stop();
+    }
+}

--- a/MasterOfPuppets/Game/Movement/NativeStop.cs
+++ b/MasterOfPuppets/Game/Movement/NativeStop.cs
@@ -1,0 +1,27 @@
+using Dalamud.Utility.Signatures;
+
+namespace MasterOfPuppets.Movement;
+
+internal unsafe sealed class NativeStop {
+    [Signature("74 0C 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ??", ScanType = ScanType.StaticAddress)]
+    private nint _moveControllerSubMemberForMineInstance = 0;
+
+    [Signature("40 53 48 83 EC ?? 48 8B 41 20 48 8B D9 80 B8 02 02 00 00 ??", ScanType = ScanType.Text)]
+    private readonly delegate* unmanaged<nint, long> _moveStop = null;
+
+    public NativeStop() {
+        DalamudApi.GameInteropProvider.InitializeFromAttributes(this);
+        DalamudApi.PluginLog.Debug($"[SimpleInputMovement] MoveControllerInstance: {_moveControllerSubMemberForMineInstance:X}");
+    }
+
+    public void Stop() {
+        if (_moveStop == null || _moveControllerSubMemberForMineInstance == 0)
+            return;
+
+        try {
+            _moveStop(_moveControllerSubMemberForMineInstance);
+        } catch {
+            // ignored
+        }
+    }
+}

--- a/MasterOfPuppets/Game/Movement/SimpleInputMovement.cs
+++ b/MasterOfPuppets/Game/Movement/SimpleInputMovement.cs
@@ -13,6 +13,7 @@ public sealed class SimpleInputMovement : IDisposable {
     public const float ArrivalWalkBuffer = 0.5f;
     public const float SettleHysteresis = 0.05f;
     public const int SettleFrameCount = 3;
+    public const float ContinuousPassEpsilon = 0.01f;
 
     private readonly NativeStop _nativeStop = new();
     private readonly ForwardInputMovementController _forwardInput = new();
@@ -158,6 +159,22 @@ public sealed class SimpleInputMovement : IDisposable {
         };
     }
 
+    public static ContinuousMovementProgress UpdateContinuousProgress(
+        float distance,
+        float precision,
+        float? previousDistance,
+        bool hasApproached) {
+        if (distance <= precision)
+            return new ContinuousMovementProgress(true, hasApproached);
+
+        if (previousDistance is not { } previous)
+            return new ContinuousMovementProgress(false, hasApproached);
+
+        var approached = hasApproached || distance < previous - ContinuousPassEpsilon;
+        var passedClosestApproach = approached && distance > previous + ContinuousPassEpsilon;
+        return new ContinuousMovementProgress(passedClosestApproach, approached);
+    }
+
     public static string FormatMode(SimpleMovementMode mode) =>
         mode.ToString().ToLowerInvariant();
 
@@ -232,6 +249,8 @@ public enum ArrivalMovementState {
     Walk,
     Stop,
 }
+
+public readonly record struct ContinuousMovementProgress(bool Complete, bool HasApproached);
 
 public sealed class SimpleMovementProgressTracker {
     private Vector3 _lastSignificantPosition;

--- a/MasterOfPuppets/Game/Movement/SimpleInputMovement.cs
+++ b/MasterOfPuppets/Game/Movement/SimpleInputMovement.cs
@@ -3,90 +3,29 @@ using System.Numerics;
 using System.Threading;
 
 using Dalamud.Game.ClientState.Conditions;
-using Dalamud.Hooking;
-using Dalamud.Utility.Signatures;
-
-using FFXIVClientStructs.FFXIV.Client.Game.Control;
 
 using MasterOfPuppets.Extensions;
 using MasterOfPuppets.Util;
 
 namespace MasterOfPuppets.Movement;
 
-public unsafe class SimpleInputMovement : IDisposable {
+public sealed class SimpleInputMovement : IDisposable {
     public const float ArrivalWalkBuffer = 0.5f;
+    public const float SettleHysteresis = 0.05f;
+    public const int SettleFrameCount = 3;
 
-
-    [Signature("74 0C 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ??", ScanType = ScanType.StaticAddress)]
-    private nint _moveControllerSubMemberForMineInstance = 0;
-
-    [Signature("40 53 48 83 EC ?? 48 8B 41 20 48 8B D9 80 B8 02 02 00 00 ??", ScanType = ScanType.Text)]
-    private readonly delegate* unmanaged<nint, long> _moveStop = null;
-
-    /// <summary>Current injected direction. Set to None to stop injection.</summary>
-    public MovementDirection Direction {
-        get => _direction;
-        set {
-            _direction = value;
-            // Only keep the hook enabled while we are actually injecting
-            // When idle the hook is disabled so it has zero runtime cost
-            if (value == MovementDirection.None)
-                _playerMoveHook?.Disable();
-            else
-                _playerMoveHook?.Enable();
-        }
-    }
-
-    public bool IsWalking {
-        get {
-            var control = Control.Instance();
-            if (control == null) return false;
-            return control->IsWalking;
-        }
-        set {
-            var control = Control.Instance();
-            if (control == null) return;
-
-            if (control->IsWalking == value)
-                return;
-
-            control->IsWalking = value;
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // Hook
-    //
-    // Intercepts every movement input poll.  When our direction is active we
-    // return 1 (key held) for that direction code, regardless of keyboard state.
-    // This is identical to what the game sees when you physically hold a key.
-    // The hook starts disabled and is enabled only while Direction != None.
-    // -------------------------------------------------------------------------
-    private delegate byte PlayerMoveDelegate(nint a1, int direction);
-    private Hook<PlayerMoveDelegate>? _playerMoveHook;
-    private byte PlayerMoveDetour(nint a1, int dir) {
-        var original = _playerMoveHook.Original(a1, dir);
-
-        if (_direction != MovementDirection.None && dir == (int)_direction)
-            return 1;
-
-        return original;
-    }
-
-    private MovementDirection _direction;
-
-    // Active cancellation source for the current MoveTo coroutine
+    private readonly NativeStop _nativeStop = new();
+    private readonly ForwardInputMovementController _forwardInput = new();
+    private readonly ContinuousForwardMovementStrategy _continuousForward;
+    private readonly ForwardPreciseMovementStrategy _forwardPrecise;
+    private readonly ArrivePreciseMovementStrategy _arrivePrecise;
     private CancellationTokenSource? _cts;
+    private ISimpleMovementStrategy? _activeStrategy;
 
     public SimpleInputMovement() {
-        DalamudApi.GameInteropProvider.InitializeFromAttributes(this);
-        // Hook starts disabled, enabled automatically when Direction is set.
-        _playerMoveHook = DalamudApi.GameInteropProvider.HookFromSignature<PlayerMoveDelegate>(
-            "E8 ?? ?? ?? ?? 4C 63 4B 04",
-            PlayerMoveDetour
-        );
-
-        DalamudApi.PluginLog.Debug($"[SimpleInputMovement] MoveControllerInstance: {_moveControllerSubMemberForMineInstance:X}");
+        _continuousForward = new ContinuousForwardMovementStrategy(_forwardInput);
+        _forwardPrecise = new ForwardPreciseMovementStrategy(_forwardInput);
+        _arrivePrecise = new ArrivePreciseMovementStrategy(_forwardInput, _nativeStop);
     }
 
     public void Dispose() {
@@ -94,22 +33,8 @@ public unsafe class SimpleInputMovement : IDisposable {
         _cts = null;
         cts?.Cancel();
         cts?.Dispose();
-
-        Direction = MovementDirection.None;
-
-        _playerMoveHook?.Disable();
-        _playerMoveHook?.Dispose();
-        _playerMoveHook = null;
-    }
-
-    private void MoveStopNative() {
-        if (_moveStop == null || _moveControllerSubMemberForMineInstance == 0)
-            return;
-        try {
-            _moveStop(_moveControllerSubMemberForMineInstance);
-        } catch {
-            // ignored
-        }
+        StopStrategies();
+        _forwardInput.Dispose();
     }
 
     public void StopMove() {
@@ -121,40 +46,11 @@ public unsafe class SimpleInputMovement : IDisposable {
         _ = DalamudApi.Framework.RunOnFrameworkThread(() => CancelActiveMove(callNativeStop: true));
     }
 
-    private void CancelActiveMove(bool callNativeStop) {
-        var cts = _cts;
-        if (cts != null) {
-            cts.Cancel();
-            if (ReferenceEquals(_cts, cts))
-                _cts = null;
-        }
-
-        Direction = MovementDirection.None;
-        IsWalking = false;
-
-        if (!callNativeStop)
-            return;
-
-        if (DalamudApi.ObjectTable.LocalPlayer == null || !DalamudApi.ClientState.IsLoggedIn)
-            return;
-
-        try {
-            MoveStopNative();
-        } catch {
-            // ignored
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // MoveTo
-    // Returns the CancellationTokenSource so the caller can cancel externally,
-    // or null if movement was refused because Performing is already active.
-    // -------------------------------------------------------------------------
     public CancellationTokenSource? MoveTo(
         Vector3 destination,
         float precision = 0.3f,
         float? faceDirection = null,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Precise,
+        SimpleMovementMode movementMode = SimpleMovementMode.Precise,
         bool stopOnStuck = false,
         float stuckTolerance = 0.05f,
         int stuckTimeoutMs = 500) {
@@ -163,31 +59,31 @@ public unsafe class SimpleInputMovement : IDisposable {
                 destination,
                 precision,
                 faceDirection,
-                arrivalMode,
+                movementMode,
                 stopOnStuck,
                 stuckTolerance,
                 stuckTimeoutMs));
             return null;
         }
 
-        // Refuse to start while the player is performing - movement is blocked
-        // by the game anyway, so there is nothing useful we could do.
         if (DalamudApi.Condition[ConditionFlag.Performing])
             return null;
 
-        // Cancel any previous move before starting a new one. Use native stop as
-        // well so continuous moves cannot leave latched input behind.
         CancelActiveMove(callNativeStop: true);
+
+        var context = new SimpleMovementContext(destination, precision, faceDirection);
+        var strategy = SelectStrategy(movementMode);
+        strategy.Start(context);
+        _activeStrategy = strategy;
 
         var cts = new CancellationTokenSource();
         _cts = cts;
         var stuckTracker = stopOnStuck ? new SimpleMovementProgressTracker() : null;
 
-        // Snapshot current control settings so we can restore them on exit,
-        // regardless of whether we finish, are cancelled, or Performing fires.
         uint savedMoveMode = DalamudApi.GameConfig.UiControl.GetUInt("MoveMode");
         uint savedPadMode = DalamudApi.GameConfig.UiConfig.GetUInt("PadMode");
-        var savedIsWalking = IsWalking;
+        var savedIsWalking = SimpleMovementWalkState.IsWalking;
+        var movementComplete = false;
 
         DalamudApi.GameConfig.UiControl.Set("MoveMode", 0u);
         DalamudApi.GameConfig.UiConfig.Set("PadMode", 0u);
@@ -197,52 +93,32 @@ public unsafe class SimpleInputMovement : IDisposable {
                 var player = DalamudApi.ObjectTable.LocalPlayer;
                 if (player == null) return;
 
-                // If the player entered performance mode mid-move, cancel
-                // everything immediately - Stop() will clean up direction and
-                // native movement; the coroutine's callback restores settings.
                 if (DalamudApi.Condition[ConditionFlag.Performing]) {
                     StopMove();
                     return;
                 }
 
-                var distance = player.Position.Distance2D(destination);
                 if (stuckTracker != null && stuckTracker.Update(player.Position, Environment.TickCount64, stuckTolerance, stuckTimeoutMs)) {
                     DalamudApi.PluginLog.Warning(
-                        $"[SimpleInputMovement] Stuck for {stuckTimeoutMs}ms near {player.Position}; destination={destination}; stopping.");
+                        $"[SimpleInputMovement] Stuck for {stuckTimeoutMs}ms near {player.Position}; destination={destination}; mode={movementMode}; stopping.");
                     CancelActiveMove(callNativeStop: true);
                     return;
                 }
 
-                // Re-face target every frame in case the player drifts.
-                GameFunctions.FaceDirection(destination);
-
-                Direction = MovementDirection.Forward;
-
-                // Slow before the stop radius so we do not run through the destination
-                // and make repeated endpoint corrections.
-                IsWalking = GetArrivalState(distance, precision, arrivalMode) == ArrivalMovementState.Walk;
+                movementComplete = strategy.Update(context, player.Position) == SimpleMovementUpdateResult.Complete;
             },
             callback: () => {
                 var newerMoveStarted = _cts != null && !ReferenceEquals(_cts, cts);
                 if (!newerMoveStarted) {
-                    // Restore control settings unless this callback belongs to
-                    // an older move that was replaced by a newer one.
                     DalamudApi.GameConfig.UiControl.Set("MoveMode", savedMoveMode);
                     DalamudApi.GameConfig.UiConfig.Set("PadMode", savedPadMode);
 
-                    Direction = MovementDirection.None;
-                    if (arrivalMode == MovementArrivalMode.Precise) {
-                        try {
-                            MoveStopNative();
-                        } catch {
-                            // ignored
-                        }
-                    }
+                    StopStrategies();
+                    if (strategy.UsesNativeStopOnCompletion)
+                        _nativeStop.Stop();
 
-                    IsWalking = savedIsWalking;
+                    SimpleMovementWalkState.IsWalking = savedIsWalking;
 
-                    // Apply endpoint rotation only on clean arrival (not on cancel
-                    // or Performing - the player may be mid-performance already).
                     if (faceDirection is float rot
                         && !cts.IsCancellationRequested
                         && !DalamudApi.Condition[ConditionFlag.Performing]) {
@@ -255,22 +131,12 @@ public unsafe class SimpleInputMovement : IDisposable {
                 cts.Dispose();
             },
             stopWhen: () => {
-                // var player = DalamudApi.ObjectTable.LocalPlayer;
-                // if (player == null) { DalamudApi.PluginLog.Warning("stopWhen: player null"); return true; }
-                // if (!DalamudApi.ClientState.IsLoggedIn) { DalamudApi.PluginLog.Warning("stopWhen: not logged in"); return true; }
-                // if (cts.IsCancellationRequested) { DalamudApi.PluginLog.Warning("stopWhen: cancelled"); return true; }
-                // if (DalamudApi.Condition[ConditionFlag.Performing]) { DalamudApi.PluginLog.Warning("stopWhen: performing"); return true; }
-                // var dist = player.Position.Distance2D(destination);
-                // DalamudApi.PluginLog.Warning($"stopWhen: dist={dist} precision={precision}");
-                // return dist < precision;
-
                 var player = DalamudApi.ObjectTable.LocalPlayer;
-                // Stop when: arrived, logged out, cancelled, or Performing active.
-                return player == null
+                return movementComplete
+                    || player == null
                     || !DalamudApi.ClientState.IsLoggedIn
                     || cts.IsCancellationRequested
-                    || DalamudApi.Condition[ConditionFlag.Performing]
-                    || player.Position.Distance2D(destination) < precision;
+                    || DalamudApi.Condition[ConditionFlag.Performing];
             },
             cancellationToken: cts.Token);
 
@@ -280,22 +146,85 @@ public unsafe class SimpleInputMovement : IDisposable {
     public static ArrivalMovementState GetArrivalState(
         float distance,
         float precision,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Precise) {
-        if (distance < precision)
+        SimpleMovementMode movementMode = SimpleMovementMode.Precise) {
+        if (distance <= precision)
             return ArrivalMovementState.Stop;
 
-        if (arrivalMode == MovementArrivalMode.Continuous)
-            return ArrivalMovementState.Run;
+        return movementMode switch {
+            SimpleMovementMode.Continuous => ArrivalMovementState.Run,
+            SimpleMovementMode.Forward => distance <= precision + ArrivalWalkBuffer ? ArrivalMovementState.Walk : ArrivalMovementState.Run,
+            SimpleMovementMode.Precise => distance <= precision + ArrivalWalkBuffer ? ArrivalMovementState.Walk : ArrivalMovementState.Run,
+            _ => ArrivalMovementState.Run,
+        };
+    }
 
-        return distance < precision + ArrivalWalkBuffer
-            ? ArrivalMovementState.Walk
-            : ArrivalMovementState.Run;
+    public static string FormatMode(SimpleMovementMode mode) =>
+        mode.ToString().ToLowerInvariant();
+
+    public static SimpleMovementMode ParseModeOrDefault(string value, SimpleMovementMode fallback = SimpleMovementMode.Continuous) {
+        return TryParseMode(value, out var mode) ? mode : fallback;
+    }
+
+    public static bool TryParseMode(string value, out SimpleMovementMode mode) {
+        mode = SimpleMovementMode.Continuous;
+        if (value.Equals("continuous", StringComparison.OrdinalIgnoreCase)) {
+            mode = SimpleMovementMode.Continuous;
+            return true;
+        }
+
+        if (value.Equals("precise", StringComparison.OrdinalIgnoreCase)) {
+            mode = SimpleMovementMode.Precise;
+            return true;
+        }
+
+        if (value.Equals("forward", StringComparison.OrdinalIgnoreCase)) {
+            mode = SimpleMovementMode.Forward;
+            return true;
+        }
+
+        return false;
+    }
+
+    private ISimpleMovementStrategy SelectStrategy(SimpleMovementMode mode) =>
+        mode switch {
+            SimpleMovementMode.Continuous => _continuousForward,
+            SimpleMovementMode.Forward => _forwardPrecise,
+            _ => _arrivePrecise,
+        };
+
+    private void CancelActiveMove(bool callNativeStop) {
+        var cts = _cts;
+        if (cts != null) {
+            cts.Cancel();
+            if (ReferenceEquals(_cts, cts))
+                _cts = null;
+        }
+
+        StopStrategies();
+        SimpleMovementWalkState.IsWalking = false;
+
+        if (!callNativeStop)
+            return;
+
+        if (DalamudApi.ObjectTable.LocalPlayer == null || !DalamudApi.ClientState.IsLoggedIn)
+            return;
+
+        _nativeStop.Stop();
+    }
+
+    private void StopStrategies() {
+        _activeStrategy?.Stop();
+        _activeStrategy = null;
+        _continuousForward.Stop();
+        _forwardPrecise.Stop();
+        _arrivePrecise.Stop();
     }
 }
 
-public enum MovementArrivalMode {
-    Precise,
+public enum SimpleMovementMode {
     Continuous,
+    Precise,
+    Forward,
 }
 
 public enum ArrivalMovementState {

--- a/MasterOfPuppets/Game/Movement/SimpleMovementContext.cs
+++ b/MasterOfPuppets/Game/Movement/SimpleMovementContext.cs
@@ -1,0 +1,21 @@
+using System.Numerics;
+
+namespace MasterOfPuppets.Movement;
+
+public readonly record struct SimpleMovementContext(
+    Vector3 Destination,
+    float Precision,
+    float? FaceDirection);
+
+internal enum SimpleMovementUpdateResult {
+    Running,
+    Complete,
+}
+
+internal interface ISimpleMovementStrategy {
+    string Name { get; }
+    bool UsesNativeStopOnCompletion { get; }
+    void Start(SimpleMovementContext context);
+    SimpleMovementUpdateResult Update(SimpleMovementContext context, Vector3 playerPosition);
+    void Stop();
+}

--- a/MasterOfPuppets/Game/Movement/SimpleMovementWalkState.cs
+++ b/MasterOfPuppets/Game/Movement/SimpleMovementWalkState.cs
@@ -1,0 +1,20 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Control;
+
+namespace MasterOfPuppets.Movement;
+
+internal static unsafe class SimpleMovementWalkState {
+    public static bool IsWalking {
+        get {
+            var control = Control.Instance();
+            if (control == null) return false;
+            return control->IsWalking;
+        }
+        set {
+            var control = Control.Instance();
+            if (control == null || control->IsWalking == value)
+                return;
+
+            control->IsWalking = value;
+        }
+    }
+}

--- a/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
@@ -18,15 +18,21 @@ internal partial class IpcProvider {
     /// The anchor's world position, facing, and content ID are included so each
     /// client can place its assigned point relative to the anchor's saved point.
     /// </summary>
-    public void ExecuteFormation(string name, bool useTargetAnchor = false) {
-        ExecuteFormation(name, useTargetAnchor ? FormationAnchorReference.Target : FormationAnchorReference.Self);
+    public void ExecuteFormation(string name, bool useTargetAnchor = false, SimpleMovementMode movementMode = SimpleMovementMode.Continuous) {
+        ExecuteFormation(name, useTargetAnchor ? FormationAnchorReference.Target : FormationAnchorReference.Self, movementMode);
     }
 
-    public void ExecuteFormation(string name, FormationAnchorReference anchor) {
-        _ = DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationOnFrameworkThread(name, anchor));
+    public void ExecuteFormation(
+        string name,
+        FormationAnchorReference anchor,
+        SimpleMovementMode movementMode = SimpleMovementMode.Continuous) {
+        _ = DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationOnFrameworkThread(name, anchor, movementMode));
     }
 
-    private void ExecuteFormationOnFrameworkThread(string name, FormationAnchorReference anchor) {
+    private void ExecuteFormationOnFrameworkThread(
+        string name,
+        FormationAnchorReference anchor,
+        SimpleMovementMode movementMode = SimpleMovementMode.Continuous) {
         var player = DalamudApi.ObjectTable.LocalPlayer;
         if (player == null) return;
 
@@ -55,7 +61,8 @@ internal partial class IpcProvider {
             anchorPos.Y.ToString("G", CultureInfo.InvariantCulture),
             anchorPos.Z.ToString("G", CultureInfo.InvariantCulture),
             anchorRot.ToString("G", CultureInfo.InvariantCulture),
-            anchorCid.ToString(CultureInfo.InvariantCulture)).Serialize(), includeSelf: true);
+            anchorCid.ToString(CultureInfo.InvariantCulture),
+            SimpleInputMovement.FormatMode(movementMode)).Serialize(), includeSelf: true);
     }
 
     [IpcHandle(IpcMessageType.ExecuteFormation)]
@@ -71,6 +78,9 @@ internal partial class IpcProvider {
         if (!float.TryParse(message.StringData[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float lz)) return;
         if (!float.TryParse(message.StringData[4], NumberStyles.Float, CultureInfo.InvariantCulture, out float anchorRot)) return;
         if (!ulong.TryParse(message.StringData[5], NumberStyles.Integer, CultureInfo.InvariantCulture, out ulong anchorCid)) return;
+        var movementMode = message.StringData.Length >= 7
+            ? SimpleInputMovement.ParseModeOrDefault(message.StringData[6], SimpleMovementMode.Continuous)
+            : SimpleMovementMode.Continuous;
 
         var formation = Plugin.Config.Formations.FirstOrDefault(f =>
             string.Equals(f.Name, name, StringComparison.OrdinalIgnoreCase));
@@ -93,7 +103,7 @@ internal partial class IpcProvider {
         // DalamudApi.PluginLog.Warning($"[ExecuteFormation] anchorPos: {anchorPos} worldPos: {worldPos} faceDirection: {facingRad}");
 
         // Plugin.MovementManager.MoveTo(worldPos, facingRad.Radians());
-        FormationLocalMovementExecutor.MoveToComputed(Plugin, worldPos, facingRad);
+        FormationLocalMovementExecutor.MoveToComputed(Plugin, worldPos, facingRad, movementMode);
 
         // Member faces the same direction as the anchor (north offset = 0)
         // Plugin.MovementManager.MoveTo(worldPos, anchorRot.Radians());
@@ -104,14 +114,14 @@ internal partial class IpcProvider {
         bool reverse = false,
         int step = 1,
         int sequenceIndex = 0,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
+        SimpleMovementMode movementMode = SimpleMovementMode.Continuous,
         FormationMoveAnchorMode anchorMode = FormationMoveAnchorMode.Self) =>
         ExecuteFormationMove(
             name,
             reverse,
             step,
             sequenceIndex,
-            arrivalMode,
+            movementMode,
             anchorMode == FormationMoveAnchorMode.Target ? FormationAnchorReference.Target : FormationAnchorReference.Self);
 
     public Task ExecuteFormationMove(
@@ -119,14 +129,14 @@ internal partial class IpcProvider {
         bool reverse = false,
         int step = 1,
         int sequenceIndex = 0,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
+        SimpleMovementMode movementMode = SimpleMovementMode.Continuous,
         FormationAnchorReference? anchor = null) =>
         DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationMoveOnFrameworkThread(
             name,
             reverse,
             step,
             sequenceIndex,
-            arrivalMode,
+            movementMode,
             anchor ?? FormationAnchorReference.Self));
 
     private void ExecuteFormationMoveOnFrameworkThread(
@@ -134,7 +144,7 @@ internal partial class IpcProvider {
         bool reverse = false,
         int step = 1,
         int sequenceIndex = 0,
-        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
+        SimpleMovementMode movementMode = SimpleMovementMode.Continuous,
         FormationAnchorReference? anchor = null) {
         var player = DalamudApi.ObjectTable.LocalPlayer;
         if (player == null) return;
@@ -169,7 +179,7 @@ internal partial class IpcProvider {
             reverse ? "1" : "0",
             Math.Max(1, step).ToString(CultureInfo.InvariantCulture),
             sequenceIndex.ToString(CultureInfo.InvariantCulture),
-            arrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous",
+            SimpleInputMovement.FormatMode(movementMode),
             effectiveAnchor.Kind == FormationAnchorKind.Target ? "target" : "self").Serialize(), includeSelf: true);
     }
 
@@ -189,9 +199,9 @@ internal partial class IpcProvider {
         var reverse = message.StringData[6] == "1";
         if (!int.TryParse(message.StringData[7], NumberStyles.Integer, CultureInfo.InvariantCulture, out var step)) return;
         if (!int.TryParse(message.StringData[8], NumberStyles.Integer, CultureInfo.InvariantCulture, out var sequenceIndex)) return;
-        var arrivalMode = message.StringData.Length >= 10 && message.StringData[9].Equals("precise", StringComparison.OrdinalIgnoreCase)
-            ? MovementArrivalMode.Precise
-            : MovementArrivalMode.Continuous;
+        var movementMode = message.StringData.Length >= 10
+            ? SimpleInputMovement.ParseModeOrDefault(message.StringData[9], SimpleMovementMode.Continuous)
+            : SimpleMovementMode.Continuous;
         var formation = Plugin.Config.Formations.FirstOrDefault(f =>
             string.Equals(f.Name, name, StringComparison.OrdinalIgnoreCase));
         if (formation == null) {
@@ -223,7 +233,7 @@ internal partial class IpcProvider {
         if (move == null)
             return;
 
-        FormationLocalMovementExecutor.MoveToComputed(Plugin, move.Value.Position, move.Value.Rotation, arrivalMode);
+        FormationLocalMovementExecutor.MoveToComputed(Plugin, move.Value.Position, move.Value.Rotation, movementMode);
     }
 
     private FormationPoint? GetAssignedPoint(Formation formation, ulong playerCid) =>

--- a/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
@@ -19,10 +19,14 @@ internal partial class IpcProvider {
     /// client can place its assigned point relative to the anchor's saved point.
     /// </summary>
     public void ExecuteFormation(string name, bool useTargetAnchor = false) {
-        _ = DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationOnFrameworkThread(name, useTargetAnchor));
+        ExecuteFormation(name, useTargetAnchor ? FormationAnchorReference.Target : FormationAnchorReference.Self);
     }
 
-    private void ExecuteFormationOnFrameworkThread(string name, bool useTargetAnchor = false) {
+    public void ExecuteFormation(string name, FormationAnchorReference anchor) {
+        _ = DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationOnFrameworkThread(name, anchor));
+    }
+
+    private void ExecuteFormationOnFrameworkThread(string name, FormationAnchorReference anchor) {
         var player = DalamudApi.ObjectTable.LocalPlayer;
         if (player == null) return;
 
@@ -42,7 +46,7 @@ internal partial class IpcProvider {
             return;
         }
 
-        if (!TryGetFormationAnchor(useTargetAnchor, issuerCid, out var anchorPos, out var anchorRot, out var anchorCid))
+        if (!TryGetFormationAnchor(formation, anchor, issuerCid, out var anchorPos, out var anchorRot, out var anchorCid))
             return;
 
         BroadCast(IpcMessage.Create(IpcMessageType.ExecuteFormation,
@@ -89,13 +93,7 @@ internal partial class IpcProvider {
         // DalamudApi.PluginLog.Warning($"[ExecuteFormation] anchorPos: {anchorPos} worldPos: {worldPos} faceDirection: {facingRad}");
 
         // Plugin.MovementManager.MoveTo(worldPos, facingRad.Radians());
-        Plugin.SimpleInputMovement.MoveTo(
-            worldPos,
-            precision: Plugin.Config.FormationMovePrecision,
-            faceDirection: facingRad,
-            stopOnStuck: Plugin.Config.StopOnStuck,
-            stuckTolerance: Plugin.Config.StuckTolerance,
-            stuckTimeoutMs: Plugin.Config.StuckTimeoutMs);
+        FormationLocalMovementExecutor.MoveToComputed(Plugin, worldPos, facingRad);
 
         // Member faces the same direction as the anchor (north offset = 0)
         // Plugin.MovementManager.MoveTo(worldPos, anchorRot.Radians());
@@ -108,7 +106,28 @@ internal partial class IpcProvider {
         int sequenceIndex = 0,
         MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
         FormationMoveAnchorMode anchorMode = FormationMoveAnchorMode.Self) =>
-        DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationMoveOnFrameworkThread(name, reverse, step, sequenceIndex, arrivalMode, anchorMode));
+        ExecuteFormationMove(
+            name,
+            reverse,
+            step,
+            sequenceIndex,
+            arrivalMode,
+            anchorMode == FormationMoveAnchorMode.Target ? FormationAnchorReference.Target : FormationAnchorReference.Self);
+
+    public Task ExecuteFormationMove(
+        string name,
+        bool reverse = false,
+        int step = 1,
+        int sequenceIndex = 0,
+        MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
+        FormationAnchorReference? anchor = null) =>
+        DalamudApi.Framework.RunOnFrameworkThread(() => ExecuteFormationMoveOnFrameworkThread(
+            name,
+            reverse,
+            step,
+            sequenceIndex,
+            arrivalMode,
+            anchor ?? FormationAnchorReference.Self));
 
     private void ExecuteFormationMoveOnFrameworkThread(
         string name,
@@ -116,7 +135,7 @@ internal partial class IpcProvider {
         int step = 1,
         int sequenceIndex = 0,
         MovementArrivalMode arrivalMode = MovementArrivalMode.Continuous,
-        FormationMoveAnchorMode anchorMode = FormationMoveAnchorMode.Self) {
+        FormationAnchorReference? anchor = null) {
         var player = DalamudApi.ObjectTable.LocalPlayer;
         if (player == null) return;
 
@@ -136,7 +155,8 @@ internal partial class IpcProvider {
             return;
         }
 
-        if (!TryGetFormationAnchor(anchorMode == FormationMoveAnchorMode.Target, issuerCid, out var anchorPos, out var anchorRot, out var anchorCid))
+        var effectiveAnchor = anchor ?? FormationAnchorReference.Self;
+        if (!TryGetFormationAnchor(formation, effectiveAnchor, issuerCid, out var anchorPos, out var anchorRot, out var anchorCid))
             return;
 
         BroadCast(IpcMessage.Create(IpcMessageType.ExecuteFormationMove,
@@ -150,7 +170,7 @@ internal partial class IpcProvider {
             Math.Max(1, step).ToString(CultureInfo.InvariantCulture),
             sequenceIndex.ToString(CultureInfo.InvariantCulture),
             arrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous",
-            anchorMode == FormationMoveAnchorMode.Target ? "target" : "self").Serialize(), includeSelf: true);
+            effectiveAnchor.Kind == FormationAnchorKind.Target ? "target" : "self").Serialize(), includeSelf: true);
     }
 
     [IpcHandle(IpcMessageType.ExecuteFormationMove)]
@@ -203,20 +223,19 @@ internal partial class IpcProvider {
         if (move == null)
             return;
 
-        Plugin.SimpleInputMovement.MoveTo(
-            move.Value.Position,
-            precision: Plugin.Config.FormationMovePrecision,
-            faceDirection: move.Value.Rotation,
-            arrivalMode: arrivalMode,
-            stopOnStuck: Plugin.Config.StopOnStuck,
-            stuckTolerance: Plugin.Config.StuckTolerance,
-            stuckTimeoutMs: Plugin.Config.StuckTimeoutMs);
+        FormationLocalMovementExecutor.MoveToComputed(Plugin, move.Value.Position, move.Value.Rotation, arrivalMode);
     }
 
     private FormationPoint? GetAssignedPoint(Formation formation, ulong playerCid) =>
         FormationExecution.GetAssignedPoint(formation, playerCid, Plugin.Config.CidsGroups);
 
-    private bool TryGetFormationAnchor(bool useTargetAnchor, ulong issuerCid, out Vector3 position, out float rotation, out ulong cid) {
+    private bool TryGetFormationAnchor(
+        Formation formation,
+        FormationAnchorReference anchor,
+        ulong issuerCid,
+        out Vector3 position,
+        out float rotation,
+        out ulong cid) {
         position = default;
         rotation = default;
         cid = default;
@@ -224,30 +243,17 @@ internal partial class IpcProvider {
         var player = DalamudApi.ObjectTable.LocalPlayer;
         if (player == null) return false;
 
-        if (!useTargetAnchor) {
-            position = player.Position;
-            rotation = player.Rotation;
-            cid = issuerCid;
-            return cid != 0;
-        }
+        if (anchor.Kind == FormationAnchorKind.Default)
+            anchor = FormationAnchorReference.Self;
 
-        var targetObjectId = player.TargetObjectId;
-        if (targetObjectId == 0) {
-            DalamudApi.ShowNotification("No target selected for formation anchor.", NotificationType.Error, 5000);
+        if (!FormationAnchorResolver.TryResolve(Plugin, formation, anchor, out var resolved, out var failureReason)) {
+            DalamudApi.ShowNotification(failureReason, NotificationType.Error, 5000);
             return false;
         }
 
-        var target = player.TargetObject?.GameObjectId == targetObjectId
-            ? player.TargetObject
-            : DalamudApi.ObjectTable.FirstOrDefault(o => o?.GameObjectId == targetObjectId);
-        if (target == null) {
-            DalamudApi.ShowNotification("Could not resolve formation target.", NotificationType.Error, 5000);
-            return false;
-        }
-
-        position = target.Position;
-        rotation = target.Rotation;
+        position = resolved.Position;
+        rotation = resolved.Rotation;
         cid = issuerCid;
-        return true;
+        return cid != 0;
     }
 }

--- a/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
+++ b/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
@@ -24,7 +24,7 @@ public sealed class FormationMacroGeneratorOptions {
     public bool ClosedLoop { get; set; } = true;
     public int Step { get; set; } = 1;
     public bool Reverse { get; set; }
-    public MovementArrivalMode FormationMoveArrivalMode { get; set; } = MovementArrivalMode.Continuous;
+    public SimpleMovementMode FormationMoveMode { get; set; } = SimpleMovementMode.Continuous;
     public FormationMoveAnchorMode FormationMoveAnchorMode { get; set; } = FormationMoveAnchorMode.Self;
     public int Precision { get; set; } = 2;
     public bool UseMatchingGroups { get; set; }
@@ -127,11 +127,11 @@ public static class FormationMacroGenerator {
         var step = Math.Max(1, options.Step);
         var waitOrder = SequenceFrom(destinations[0].Index, destinations, step, options.Reverse);
         var waits = SegmentDelays(waitOrder, anchor, options);
-        var arrivalMode = options.FormationMoveArrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous";
+        var movementMode = SimpleInputMovement.FormatMode(options.FormationMoveMode);
         var anchorMode = options.FormationMoveAnchorMode == FormationMoveAnchorMode.Target ? " target" : string.Empty;
         var lines = new List<string>();
         for (var i = 0; i < waits.Count; i++) {
-            lines.Add($"/mopformationmove \"{ArgumentParser.EscapeQuotedArgument(formationName)}\" {direction} {step} {i} {arrivalMode}{anchorMode}");
+            lines.Add($"/mopformationmove \"{ArgumentParser.EscapeQuotedArgument(formationName)}\" {direction} {step} {i} {movementMode}{anchorMode}");
             lines.Add($"/mopwait {waits[i].ToString("F2", CultureInfo.InvariantCulture)}");
         }
 
@@ -157,7 +157,7 @@ public static class FormationMacroGenerator {
             return;
 
         var step = Math.Max(1, options.Step);
-        var arrivalMode = options.FormationMoveArrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous";
+        var movementMode = SimpleInputMovement.FormatMode(options.FormationMoveMode);
         var anchorArg = options.FormationMoveAnchorMode == FormationMoveAnchorMode.Target
             ? " anchor=target"
             : string.IsNullOrWhiteSpace(options.OriginReference)
@@ -174,7 +174,7 @@ public static class FormationMacroGenerator {
             var lines = new List<string>();
             for (int i = 0; i < order.Count; i++) {
                 lines.Add(
-                    $"/mopformationgoto \"{ArgumentParser.EscapeQuotedArgument(formationName)}\" {order[i].Index + 1}{anchorArg} {arrivalMode}");
+                    $"/mopformationgoto \"{ArgumentParser.EscapeQuotedArgument(formationName)}\" {order[i].Index + 1}{anchorArg} {movementMode}");
                 lines.Add($"/mopwait {waits[i].ToString("F2", CultureInfo.InvariantCulture)}");
             }
 

--- a/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
+++ b/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
@@ -16,6 +16,7 @@ public sealed class FormationMacroGeneratorOptions {
     public int AnchorPointIndex { get; set; }
     public string OriginReference { get; set; } = string.Empty;
     public bool UseFormationMoveCommand { get; set; }
+    public bool UseLocalFormationPointCommand { get; set; }
     public string FormationMoveName { get; set; } = string.Empty;
     public ulong OriginContentId { get; set; }
     public float TravelSecondsPerUnit { get; set; } = 0.2f;
@@ -69,7 +70,9 @@ public static class FormationMacroGenerator {
         if (formation.Points.Count == 0)
             return new FormationMacroGenerationResult { Macro = new Macro { Name = options.MacroName } };
 
-        var anchorIndex = Math.Clamp(options.AnchorPointIndex, 0, formation.Points.Count - 1);
+        var anchorIndex = options.UseLocalFormationPointCommand
+            ? FormationPointMovement.AnchorPointIndex
+            : Math.Clamp(options.AnchorPointIndex, 0, formation.Points.Count - 1);
         var anchor = formation.Points[anchorIndex];
         var destinations = formation.Points
             .Select((point, index) => new IndexedPoint(index, point))
@@ -88,6 +91,8 @@ public static class FormationMacroGenerator {
         if (options.Mode is FormationMacroGeneratorMode.Movement or FormationMacroGeneratorMode.MovementAndPetPlacement) {
             if (options.UseFormationMoveCommand)
                 AddFormationMoveCommand(macro, destinations, anchor, formation, options, warnings);
+            else if (options.UseLocalFormationPointCommand)
+                AddLocalFormationPointCommands(macro, destinations, anchor, formation, options, groups);
             else
                 AddMovementCommands(macro, destinations, anchor, options, groups);
         }
@@ -136,6 +141,50 @@ public static class FormationMacroGenerator {
             GroupIds = [],
             Actions = string.Join("\n", lines),
         });
+    }
+
+    private static void AddLocalFormationPointCommands(
+        Macro macro,
+        IReadOnlyList<IndexedPoint> destinations,
+        FormationPoint anchor,
+        Formation formation,
+        FormationMacroGeneratorOptions options,
+        IReadOnlyList<CidGroup>? groups) {
+        var formationName = string.IsNullOrWhiteSpace(options.FormationMoveName)
+            ? formation.Name
+            : options.FormationMoveName.Trim();
+        if (string.IsNullOrWhiteSpace(formationName))
+            return;
+
+        var step = Math.Max(1, options.Step);
+        var arrivalMode = options.FormationMoveArrivalMode == MovementArrivalMode.Precise ? "precise" : "continuous";
+        var anchorArg = options.FormationMoveAnchorMode == FormationMoveAnchorMode.Target
+            ? " anchor=target"
+            : string.IsNullOrWhiteSpace(options.OriginReference)
+                ? " anchor=self"
+                : $" anchor=\"{ArgumentParser.EscapeQuotedArgument(options.OriginReference)}\"";
+
+        foreach (var start in destinations) {
+            var assignment = BuildAssignment(start.Point, groups, options.UseMatchingGroups);
+            if (assignment.IsEmpty)
+                continue;
+
+            var order = SequenceFrom(start.Index, destinations, step, options.Reverse);
+            var waits = SegmentDelays(order, anchor, options);
+            var lines = new List<string>();
+            for (int i = 0; i < order.Count; i++) {
+                lines.Add(
+                    $"/mopformationgoto \"{ArgumentParser.EscapeQuotedArgument(formationName)}\" {order[i].Index + 1}{anchorArg} {arrivalMode}");
+                lines.Add($"/mopwait {waits[i].ToString("F2", CultureInfo.InvariantCulture)}");
+            }
+
+            lines.Add("/moploop");
+            macro.Commands.Add(new Command {
+                Cids = assignment.Cids,
+                GroupIds = assignment.GroupIds,
+                Actions = string.Join("\n", lines),
+            });
+        }
     }
 
     private static void AddMovementCommands(

--- a/MasterOfPuppets/MopMacro/MacroHandler.Movement.cs
+++ b/MasterOfPuppets/MopMacro/MacroHandler.Movement.cs
@@ -22,7 +22,7 @@ public partial class MacroHandler {
         bool Reverse,
         int Step,
         int SequenceIndex,
-        MovementArrivalMode ArrivalMode,
+        SimpleMovementMode MovementMode,
         FormationAnchorReference Anchor,
         string? InvalidArgument) {
         public FormationMoveAnchorMode AnchorMode => Anchor.Kind == FormationAnchorKind.Target
@@ -34,7 +34,7 @@ public partial class MacroHandler {
         string FormationName,
         int PointIndex,
         FormationAnchorReference Anchor,
-        MovementArrivalMode ArrivalMode,
+        SimpleMovementMode MovementMode,
         string? InvalidArgument) {
         public FormationGotoAnchorKind AnchorKind => Anchor.Kind switch {
             FormationAnchorKind.Target => FormationGotoAnchorKind.Target,
@@ -70,7 +70,7 @@ public partial class MacroHandler {
             reverse,
             step,
             sequenceIndex,
-            anchorParse.ArrivalMode,
+            anchorParse.MovementMode,
             anchorParse.Anchor,
             anchorParse.InvalidArgument);
     }
@@ -85,7 +85,7 @@ public partial class MacroHandler {
                 parts[0],
                 -1,
                 FormationAnchorReference.Self,
-                MovementArrivalMode.Continuous,
+                SimpleMovementMode.Continuous,
                 parts[1]);
         }
 
@@ -97,7 +97,7 @@ public partial class MacroHandler {
             parts[0],
             pointNumber - 1,
             anchorParse.Anchor,
-            anchorParse.ArrivalMode,
+            anchorParse.MovementMode,
             anchorParse.InvalidArgument);
     }
 
@@ -175,10 +175,10 @@ public partial class MacroHandler {
             options.Reverse,
             options.Step,
             options.SequenceIndex,
-            options.ArrivalMode,
+            options.MovementMode,
             options.Anchor);
         DalamudApi.PluginLog.Debug(
-            $"[mopformationmove] formation=\"{options.FormationName}\" reverse={options.Reverse} stride={options.Step} sequenceIndex={options.SequenceIndex} arrivalMode={options.ArrivalMode} anchor={options.Anchor}");
+            $"[mopformationmove] formation=\"{options.FormationName}\" reverse={options.Reverse} stride={options.Step} sequenceIndex={options.SequenceIndex} movementMode={options.MovementMode} anchor={options.Anchor}");
     }
 
     /// <summary>
@@ -206,7 +206,7 @@ public partial class MacroHandler {
                 options.FormationName,
                 options.PointIndex,
                 options.Anchor,
-                options.ArrivalMode));
+                options.MovementMode));
     }
 
     private static string FormatFormationGotoAnchor(FormationGotoCommandOptions options) =>

--- a/MasterOfPuppets/MopMacro/MacroHandler.Movement.cs
+++ b/MasterOfPuppets/MopMacro/MacroHandler.Movement.cs
@@ -11,14 +11,39 @@ using MasterOfPuppets.Util;
 namespace MasterOfPuppets;
 
 public partial class MacroHandler {
+    public enum FormationGotoAnchorKind {
+        Self,
+        Target,
+        Named,
+    }
+
     public sealed record FormationMoveCommandOptions(
         string FormationName,
         bool Reverse,
         int Step,
         int SequenceIndex,
         MovementArrivalMode ArrivalMode,
-        FormationMoveAnchorMode AnchorMode,
-        string? InvalidArgument);
+        FormationAnchorReference Anchor,
+        string? InvalidArgument) {
+        public FormationMoveAnchorMode AnchorMode => Anchor.Kind == FormationAnchorKind.Target
+            ? FormationMoveAnchorMode.Target
+            : FormationMoveAnchorMode.Self;
+    }
+
+    public sealed record FormationGotoCommandOptions(
+        string FormationName,
+        int PointIndex,
+        FormationAnchorReference Anchor,
+        MovementArrivalMode ArrivalMode,
+        string? InvalidArgument) {
+        public FormationGotoAnchorKind AnchorKind => Anchor.Kind switch {
+            FormationAnchorKind.Target => FormationGotoAnchorKind.Target,
+            FormationAnchorKind.Named => FormationGotoAnchorKind.Named,
+            _ => FormationGotoAnchorKind.Self,
+        };
+
+        public string? AnchorName => Anchor.Name;
+    }
 
     public static FormationMoveCommandOptions? ParseFormationMoveCommandArgs(string args) {
         var parts = ArgumentParser.ParseMacroArgs(args);
@@ -36,23 +61,44 @@ public partial class MacroHandler {
         if (parts.Count >= 4 && !int.TryParse(parts[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out sequenceIndex))
             sequenceIndex = 0;
 
-        var arrivalMode = MovementArrivalMode.Continuous;
-        var anchorMode = FormationMoveAnchorMode.Self;
-        string? invalidArgument = null;
-        foreach (var part in parts.Skip(4)) {
-            if (part.Equals("precise", System.StringComparison.OrdinalIgnoreCase))
-                arrivalMode = MovementArrivalMode.Precise;
-            else if (part.Equals("continuous", System.StringComparison.OrdinalIgnoreCase))
-                arrivalMode = MovementArrivalMode.Continuous;
-            else if (part.Equals("target", System.StringComparison.OrdinalIgnoreCase))
-                anchorMode = FormationMoveAnchorMode.Target;
-            else if (part.Equals("self", System.StringComparison.OrdinalIgnoreCase))
-                anchorMode = FormationMoveAnchorMode.Self;
-            else
-                invalidArgument ??= part;
+        var anchorParse = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            parts.Skip(4),
+            FormationAnchorReference.Self);
+
+        return new FormationMoveCommandOptions(
+            parts[0],
+            reverse,
+            step,
+            sequenceIndex,
+            anchorParse.ArrivalMode,
+            anchorParse.Anchor,
+            anchorParse.InvalidArgument);
+    }
+
+    public static FormationGotoCommandOptions? ParseFormationGotoCommandArgs(string args) {
+        var parts = ArgumentParser.ParseMacroArgs(args);
+        if (parts.Count < 2)
+            return null;
+
+        if (!int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var pointNumber) || pointNumber < 1) {
+            return new FormationGotoCommandOptions(
+                parts[0],
+                -1,
+                FormationAnchorReference.Self,
+                MovementArrivalMode.Continuous,
+                parts[1]);
         }
 
-        return new FormationMoveCommandOptions(parts[0], reverse, step, sequenceIndex, arrivalMode, anchorMode, invalidArgument);
+        var anchorParse = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            parts.Skip(2),
+            FormationAnchorReference.Self);
+
+        return new FormationGotoCommandOptions(
+            parts[0],
+            pointNumber - 1,
+            anchorParse.Anchor,
+            anchorParse.ArrivalMode,
+            anchorParse.InvalidArgument);
     }
 
     /// <summary>
@@ -130,10 +176,41 @@ public partial class MacroHandler {
             options.Step,
             options.SequenceIndex,
             options.ArrivalMode,
-            options.AnchorMode);
+            options.Anchor);
         DalamudApi.PluginLog.Debug(
-            $"[mopformationmove] formation=\"{options.FormationName}\" reverse={options.Reverse} stride={options.Step} sequenceIndex={options.SequenceIndex} arrivalMode={options.ArrivalMode} anchorMode={options.AnchorMode}");
+            $"[mopformationmove] formation=\"{options.FormationName}\" reverse={options.Reverse} stride={options.Step} sequenceIndex={options.SequenceIndex} arrivalMode={options.ArrivalMode} anchor={options.Anchor}");
     }
+
+    /// <summary>
+    /// /mopformationgoto "Formation Name" pointNumber [anchor=self|target|"Character Name@World"] [continuous|precise]
+    /// Moves the local client to one saved formation point using point 1 as the live anchor.
+    /// </summary>
+    private async Task HandleMopFormationGoto(string macroId, string args, CancellationToken token) {
+        var options = ParseFormationGotoCommandArgs(args);
+        if (options == null) {
+            DalamudApi.PluginLog.Warning("[mopformationgoto] missing formation name or point number");
+            return;
+        }
+
+        if (options.InvalidArgument != null)
+            DalamudApi.PluginLog.Warning($"[mopformationgoto] invalid argument: \"{options.InvalidArgument}\"");
+
+        if (options.PointIndex < 0) {
+            DalamudApi.PluginLog.Warning($"[mopformationgoto] invalid point number: \"{options.InvalidArgument}\"");
+            return;
+        }
+
+        await DalamudApi.Framework.RunOnFrameworkThread(() =>
+            FormationLocalMovementExecutor.ExecuteFormationGoto(
+                Plugin,
+                options.FormationName,
+                options.PointIndex,
+                options.Anchor,
+                options.ArrivalMode));
+    }
+
+    private static string FormatFormationGotoAnchor(FormationGotoCommandOptions options) =>
+        options.Anchor.ToString();
 
     /// <summary>/mopmovetotarget - moves to the current target's world position.</summary>
     private Task HandleMopMoveToTarget(string macroId, string args, CancellationToken token) {

--- a/MasterOfPuppets/MopMacro/MacroHandler.cs
+++ b/MasterOfPuppets/MopMacro/MacroHandler.cs
@@ -128,6 +128,7 @@ public partial class MacroHandler : IDisposable {
             ["mopmove"] = new(HandleMopMove),
             ["mopmoverelativeto"] = new(HandleMopMoveRelativeTo),
             ["mopformationmove"] = new(HandleMopFormationMove),
+            ["mopformationgoto"] = new(HandleMopFormationGoto),
             ["mopmovetotarget"] = new(HandleMopMoveToTarget),
             ["mopmovetocharacter"] = new(HandleMopMoveToCharacter),
             ["mopstopmove"] = new(HandleMopStopMove),

--- a/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
+++ b/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
@@ -759,6 +759,23 @@ public static class MopCommandsHelper {
                 /ac heal <t> => /ac heal [t]
             """
         },
+        new MopAction
+        {
+            Category = MopActionCategory.ChatSyncCommand,
+            TextCommand = "mopformation \"Formation Name\" [self|target|\"Character Name\"|\"Character Name@World\"] [continuous|precise]",
+            SuggestionCommand = "mopformation ",
+            Example = """
+            Move each chat-sync client to its assigned point in a shared formation:
+                mopformation "Tight Circle"
+                mopformation "Tight Circle" target precise
+                mopformation "Tight Circle" "Anchor Character@World"
+            """,
+            Notes = """
+            * This is a chat sync command - all clients reading the chat resolve and move only their local character.
+            * Without an explicit anchor, point 1's assigned character is used as the live anchor and must be visible.
+            * All clients need the same formation imported or configured.
+            """
+        },
         new MopAction {
             Category = MopActionCategory.ChatSyncCommand,
             TextCommand = "mopstop",
@@ -1215,6 +1232,24 @@ public static class MopCommandsHelper {
             Add precise to walk near the destination and hard-stop on arrival.
             Add target to anchor the movement at your current target.
             Generated formation macros use one line per movement so waits, pet actions, and other macro actions can run between moves.
+            """
+        },
+
+        new MopAction
+        {
+            Category = MopActionCategory.MacroAction,
+            TextCommand = "/mopformationgoto \"Formation Name\" <pointNumber> [anchor=<self|target|\"Character Name@World\">] [continuous|precise]",
+            SuggestionCommand = "/mopformationgoto \"Formation Name\" 2 anchor=\"Character Name@World\"",
+            Example = """
+            /mopformationgoto "Circle" 2 anchor="Anchor Character@World"
+            /mopformationgoto "Circle" 3 anchor=target precise
+            /mopformationgoto "Circle" 4 anchor=self
+            """,
+            Notes = """
+            Moves only this client to a specific saved formation point.
+            Point numbers are 1-based; point 1 is always the live anchor/origin.
+            Use anchor="Name@World" when each PC should place itself relative to the same visible anchor character.
+            This is the precise local alternative to IPC-broadcast /mopformationmove.
             """
         },
 

--- a/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
+++ b/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
@@ -773,6 +773,7 @@ public static class MopCommandsHelper {
             Notes = """
             * This is a chat sync command - all clients reading the chat resolve and move only their local character.
             * Without an explicit anchor, point 1's assigned character is used as the live anchor and must be visible.
+            * continuous does not toggle walk; precise walks near the destination for better placement.
             * All clients need the same formation imported or configured.
             """
         },
@@ -1229,7 +1230,7 @@ public static class MopCommandsHelper {
             Broadcasts one saved-formation movement step from the current character.
             Stride is the skip amount through formation point order; sequenceIndex is the zero-based step to execute from each recipient's computed path.
             By default, movement is continuous for smoother looping animations.
-            Add precise to walk near the destination and hard-stop on arrival.
+            continuous does not toggle walk; precise walks near the destination for better placement.
             Add target to anchor the movement at your current target.
             Generated formation macros use one line per movement so waits, pet actions, and other macro actions can run between moves.
             """
@@ -1249,6 +1250,7 @@ public static class MopCommandsHelper {
             Moves only this client to a specific saved formation point.
             Point numbers are 1-based; point 1 is always the live anchor/origin.
             Use anchor="Name@World" when each PC should place itself relative to the same visible anchor character.
+            continuous does not toggle walk; precise walks near the destination for better placement.
             This is the precise local alternative to IPC-broadcast /mopformationmove.
             """
         },
@@ -1473,17 +1475,20 @@ public static class MopCommandsHelper {
         },
         new MopAction {
             Category = MopActionCategory.PluginCommand,
-            TextCommand = "/mop formation \"Formation Name\"",
+            TextCommand = "/mop formation \"Formation Name\" [self|target] [continuous|precise]",
             SuggestionCommand = "/mop formation ",
             Example = """
             /mop formation "My Formation"
             /mop formation "My Formation" target
+            /mop formation "My Formation" precise
+            /mop formation "My Formation" target precise
             """,
             Notes = """
             * This is a plugin command (works only on local clients)
             Broadcasts formation execution to all local clients.
             Each client moves to the formation point whose assigned CIDs/groups include it.
             Add target to place your assigned formation point at your current target.
+            continuous does not toggle walk; precise walks near the destination for better placement.
             """
         },
         new MopAction {

--- a/MasterOfPuppets/Ui/Windows/FormationWindow/FormationWindow.LeftPanel.cs
+++ b/MasterOfPuppets/Ui/Windows/FormationWindow/FormationWindow.LeftPanel.cs
@@ -9,6 +9,7 @@ using Dalamud.Interface.ImGuiNotification;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 
+using MasterOfPuppets.Formations;
 using MasterOfPuppets.Resources;
 using MasterOfPuppets.Util;
 using MasterOfPuppets.Util.ImGuiExt;
@@ -247,6 +248,21 @@ public partial class FormationWindow {
                             DalamudApi.ShowNotification(Language.ClipboardCopyMessage, NotificationType.Info, 5000);
                         }
 
+                        ImGui.Separator();
+                        if (ImGui.MenuItem("Copy Formation Code")) {
+                            ImGui.SetClipboardText(FormationShareCode.Export(f, includeAssignments: true));
+                            DalamudApi.ShowNotification(Language.ClipboardCopyMessage, NotificationType.Info, 5000);
+                        }
+
+                        if (ImGui.MenuItem("Copy Formation Code Without Assignments")) {
+                            ImGui.SetClipboardText(FormationShareCode.Export(f, includeAssignments: false));
+                            DalamudApi.ShowNotification(Language.ClipboardCopyMessage, NotificationType.Info, 5000);
+                        }
+
+                        if (ImGui.MenuItem("Import Formation Code From Clipboard")) {
+                            ImportFormationCodeFromClipboard();
+                        }
+
                         ImGui.EndPopup();
                     }
                 }
@@ -269,6 +285,21 @@ public partial class FormationWindow {
         }
 
         ImGui.EndTable();
+    }
+
+    private void ImportFormationCodeFromClipboard() {
+        var code = ImGui.GetClipboardText();
+        if (!FormationShareCode.TryImport(code, out var formation, out var error)) {
+            DalamudApi.ShowNotification(error, NotificationType.Error, 5000);
+            return;
+        }
+
+        formation.Name = FormationShareCode.GetUniqueName(formation.Name, Plugin.Config.Formations);
+        Plugin.Config.Formations.Add(formation);
+        _selFormation = Plugin.Config.Formations.Count - 1;
+        Plugin.Config.Save();
+        Plugin.IpcProvider.SyncConfiguration();
+        DalamudApi.ShowNotification($"Imported formation \"{formation.Name}\"", NotificationType.Success, 5000);
     }
 
     private void CommitRename(int i) {

--- a/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
+++ b/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
@@ -20,6 +20,7 @@ public partial class MacroEditorWindow {
     private float _macroGenTravelSecondsPerUnit = 0.2f;
     private int _macroGenStep = 1;
     private bool _macroGenReverse;
+    private int _macroGenExistingFormationCommandStyle;
     private int _macroGenFormationMoveArrivalMode;
     private int _macroGenFormationMoveAnchorMode;
     private bool _macroGenLinkPetTraversalToMovement = true;
@@ -43,6 +44,7 @@ public partial class MacroEditorWindow {
     private static readonly string[] MacroGeneratorModeNames = ["Movement", "Pet Placement", "Movement + Pet Placement"];
     private static readonly string[] MacroGeneratorSourceNames = ["Existing Formation", "Generated Shape"];
     private static readonly string[] MacroGeneratorDirectionNames = ["Forward through point order", "Backward through point order"];
+    private static readonly string[] MacroGeneratorExistingFormationCommandStyleNames = ["Broadcast formation move", "Local point commands"];
     private static readonly string[] MacroGeneratorArrivalModeNames = ["Continuous", "Precise"];
     private static readonly string[] MacroGeneratorAnchorModeNames = ["Self", "Current target"];
 
@@ -148,8 +150,8 @@ public partial class MacroEditorWindow {
         ImGui.TextDisabled(string.IsNullOrWhiteSpace(originName) ? "Could not resolve current character." : originName);
 
         if (_macroGenSource == 0) {
-            ImGui.TextDisabled("Existing formations insert one origin command with one movement line per step.");
-            ImGuiUtil.HelpMarker("Each line broadcasts one /mopformationmove step. Waits use saved point-to-point distance.");
+            ImGui.TextDisabled("Existing formations can use broadcast steps or local point commands.");
+            ImGuiUtil.HelpMarker("Broadcast uses /mopformationmove over IPC. Local point commands use /mopformationgoto on each assigned client with point 1 as the anchor.");
         }
 
         DrawMacroGenFloat("Seconds per unit", "Wait seconds per unit of path distance.", ref _macroGenTravelSecondsPerUnit, 0.01f, 0.01f, 10f, "%.2f");
@@ -291,6 +293,10 @@ public partial class MacroEditorWindow {
         }
 
         if (existingFormationMovement) {
+            DrawMacroGeneratorLabel("Command style", "Broadcast sends one IPC formation step from this client. Local point commands run independently on each assigned client using point 1 as the anchor.");
+            ImGui.SetNextItemWidth(220);
+            ImGui.Combo("##macroGenExistingFormationCommandStyle", ref _macroGenExistingFormationCommandStyle, MacroGeneratorExistingFormationCommandStyleNames, MacroGeneratorExistingFormationCommandStyleNames.Length);
+
             DrawMacroGeneratorLabel("Movement arrival", "Continuous keeps movement smooth; precise hard-stops near each point.");
             ImGui.SetNextItemWidth(160);
             ImGui.Combo("##macroGenFormationMoveArrival", ref _macroGenFormationMoveArrivalMode, MacroGeneratorArrivalModeNames, MacroGeneratorArrivalModeNames.Length);
@@ -353,6 +359,11 @@ public partial class MacroEditorWindow {
             return new MacroCommandGeneratorPreview(false, "The generated shape does not have the point assigned to your current character.", []);
 
         var movementEnabled = _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement;
+        var useLocalFormationPointCommand = _macroGenSource == 0
+            && movementEnabled
+            && _macroGenExistingFormationCommandStyle == 1;
+        if (useLocalFormationPointCommand && _macroGenFormationMoveAnchorMode == 0 && originPointIndex != FormationPointMovement.AnchorPointIndex)
+            return new MacroCommandGeneratorPreview(false, "Local point commands use point 1 as the anchor. Assign your current character to point 1, or use Current target as the movement anchor.", []);
         if (_macroGenSource == 1 && movementEnabled && string.IsNullOrWhiteSpace(GetLocalPlayerNameWorld()))
             return new MacroCommandGeneratorPreview(false, "Current character name/world must be resolved before generated shape movement commands can be created.", []);
         if (_macroGenSource == 1 && movementEnabled && GetLocalPlayerRotation() == null)
@@ -373,9 +384,15 @@ public partial class MacroEditorWindow {
         if (_macroGenSource == 0 && movementEnabled) {
             var petCommands = Math.Max(0, result.Macro.Commands.Count - 1);
             var movementSteps = Math.Max(0, sourceFormation.Points.Count - 1);
-            message = _macroGenMode == (int)FormationMacroGeneratorMode.Movement
-                ? $"Will insert 1 origin movement command containing {movementSteps} movement step(s) {insertionText}."
-                : $"Will insert 1 origin movement command containing {movementSteps} movement step(s) + {petCommands} pet command(s) {insertionText}.";
+            if (_macroGenExistingFormationCommandStyle == 0) {
+                message = _macroGenMode == (int)FormationMacroGeneratorMode.Movement
+                    ? $"Will insert 1 origin movement command containing {movementSteps} movement step(s) {insertionText}."
+                    : $"Will insert 1 origin movement command containing {movementSteps} movement step(s) + {petCommands} pet command(s) {insertionText}.";
+            } else {
+                message = _macroGenMode == (int)FormationMacroGeneratorMode.Movement
+                    ? $"Will insert {result.Macro.Commands.Count} local point movement command(s) {insertionText}."
+                    : $"Will insert local point movement commands + {petCommands} pet command(s) {insertionText}.";
+            }
         } else if (_macroGenSource == 1 && movementEnabled) {
             message = $"Will insert {result.Macro.Commands.Count} generated shape command(s) {insertionText}.";
         }
@@ -385,16 +402,21 @@ public partial class MacroEditorWindow {
 
     private FormationMacroGenerationResult GenerateMacroCommands(Formation sourceFormation, int originPointIndex) {
         var useFormationMove = _macroGenSource == 0
-            && _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement;
+            && _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement
+            && _macroGenExistingFormationCommandStyle == 0;
+        var useLocalFormationPointCommand = _macroGenSource == 0
+            && _macroGenMode != (int)FormationMacroGeneratorMode.PetPlacement
+            && _macroGenExistingFormationCommandStyle == 1;
         var originName = GetLocalPlayerNameWorld();
         var result = FormationMacroGenerator.GenerateLoopMacroWithDiagnostics(
             sourceFormation,
             new FormationMacroGeneratorOptions {
                 MacroName = MacroItem.Name,
                 Mode = (FormationMacroGeneratorMode)_macroGenMode,
-                AnchorPointIndex = originPointIndex,
+                AnchorPointIndex = useLocalFormationPointCommand ? FormationPointMovement.AnchorPointIndex : originPointIndex,
                 OriginReference = originName,
                 UseFormationMoveCommand = useFormationMove,
+                UseLocalFormationPointCommand = useLocalFormationPointCommand,
                 FormationMoveName = sourceFormation.Name,
                 OriginContentId = DalamudApi.PlayerState.ContentId,
                 TravelSecondsPerUnit = _macroGenTravelSecondsPerUnit,

--- a/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
+++ b/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
@@ -21,7 +21,7 @@ public partial class MacroEditorWindow {
     private int _macroGenStep = 1;
     private bool _macroGenReverse;
     private int _macroGenExistingFormationCommandStyle;
-    private int _macroGenFormationMoveArrivalMode;
+    private int _macroGenFormationMoveMode;
     private int _macroGenFormationMoveAnchorMode;
     private bool _macroGenLinkPetTraversalToMovement = true;
     private int _macroGenPetStep = 1;
@@ -45,7 +45,7 @@ public partial class MacroEditorWindow {
     private static readonly string[] MacroGeneratorSourceNames = ["Existing Formation", "Generated Shape"];
     private static readonly string[] MacroGeneratorDirectionNames = ["Forward through point order", "Backward through point order"];
     private static readonly string[] MacroGeneratorExistingFormationCommandStyleNames = ["Broadcast formation move", "Local point commands"];
-    private static readonly string[] MacroGeneratorArrivalModeNames = ["Continuous", "Precise"];
+    private static readonly string[] MacroGeneratorMovementModeNames = ["Continuous", "Precise"];
     private static readonly string[] MacroGeneratorAnchorModeNames = ["Self", "Current target"];
 
     private void DrawMacroCommandGeneratorModal() {
@@ -297,9 +297,9 @@ public partial class MacroEditorWindow {
             ImGui.SetNextItemWidth(220);
             ImGui.Combo("##macroGenExistingFormationCommandStyle", ref _macroGenExistingFormationCommandStyle, MacroGeneratorExistingFormationCommandStyleNames, MacroGeneratorExistingFormationCommandStyleNames.Length);
 
-            DrawMacroGeneratorLabel("Movement arrival", "Continuous keeps movement smooth; precise hard-stops near each point.");
+            DrawMacroGeneratorLabel("Movement mode", "Continuous runs without walk toggle. Precise walks near the destination for better placement.");
             ImGui.SetNextItemWidth(160);
-            ImGui.Combo("##macroGenFormationMoveArrival", ref _macroGenFormationMoveArrivalMode, MacroGeneratorArrivalModeNames, MacroGeneratorArrivalModeNames.Length);
+            ImGui.Combo("##macroGenFormationMoveMode", ref _macroGenFormationMoveMode, MacroGeneratorMovementModeNames, MacroGeneratorMovementModeNames.Length);
 
             DrawMacroGeneratorLabel("Movement anchor", "Use self position or current target position as the live anchor.");
             ImGui.SetNextItemWidth(160);
@@ -423,7 +423,10 @@ public partial class MacroEditorWindow {
                 GlobalDelaySeconds = Math.Max(0f, (float)Plugin.Config.DelayBetweenActions),
                 Step = _macroGenStep,
                 Reverse = _macroGenReverse,
-                FormationMoveArrivalMode = _macroGenFormationMoveArrivalMode == 1 ? MovementArrivalMode.Precise : MovementArrivalMode.Continuous,
+                FormationMoveMode = _macroGenFormationMoveMode switch {
+                    1 => SimpleMovementMode.Precise,
+                    _ => SimpleMovementMode.Continuous,
+                },
                 FormationMoveAnchorMode = _macroGenFormationMoveAnchorMode == 1 ? FormationMoveAnchorMode.Target : FormationMoveAnchorMode.Self,
                 ClosedLoop = true,
                 UseMatchingGroups = false,

--- a/MasterOfPuppets/Ui/Windows/SettingsWindow/SettingsWindow.cs
+++ b/MasterOfPuppets/Ui/Windows/SettingsWindow/SettingsWindow.cs
@@ -383,7 +383,11 @@ public class SettingsWindow : Window {
                 moprun number
                 moprun macro_name
                 moprun "macro name with spaces"
+                mopformation "formation name"
                 mopstop
+
+            Formation chat sync uses point 1's assigned character as the default live anchor.
+            All clients need the same formation and the anchor character must be visible.
             """);
 
         ImGui.Spacing();

--- a/MasterOfPuppetsTests/FormationExecutionTests.cs
+++ b/MasterOfPuppetsTests/FormationExecutionTests.cs
@@ -208,6 +208,119 @@ public class FormationExecutionTests
         AssertClose(1f, move.Value.Position.X);
     }
 
+    [Fact]
+    public void FormationPointMovement_UsesPointOneAsAnchor()
+    {
+        var formation = new Formation
+        {
+            Points = [
+                new FormationPoint { Offset = new Vector3(5f, 0f, 5f), Angle = 45f },
+                new FormationPoint { Offset = new Vector3(5f, 0f, 7f), Angle = -45f },
+            ],
+        };
+
+        var move = FormationPointMovement.BuildPointOneAnchoredWorldMove(
+            formation,
+            destinationPointIndex: 1,
+            anchorWorldPosition: new Vector3(10f, 0f, 20f),
+            anchorWorldRotation: MathF.PI / 2f);
+
+        Assert.NotNull(move);
+        AssertClose(12f, move.Value.Position.X);
+        AssertClose(20f, move.Value.Position.Z);
+        AssertClose(0f, move.Value.Rotation);
+    }
+
+    [Fact]
+    public void FormationPointMovement_MatchesExistingFormationMathForPointOneAnchor()
+    {
+        var formation = new Formation
+        {
+            Points = [
+                new FormationPoint { Offset = new Vector3(1f, 0f, 1f), Angle = 30f },
+                new FormationPoint { Offset = new Vector3(3f, 0f, -2f), Angle = -120f },
+            ],
+        };
+        var anchorPosition = new Vector3(-5f, 0f, 8f);
+        var anchorRotation = -MathF.PI / 3f;
+
+        var direct = FormationMath.GetMopRelativeWorld(
+            formation.Points[0],
+            formation.Points[1],
+            anchorPosition,
+            anchorRotation);
+        var helper = FormationPointMovement.BuildPointOneAnchoredWorldMove(
+            formation,
+            destinationPointIndex: 1,
+            anchorPosition,
+            anchorRotation);
+
+        Assert.NotNull(helper);
+        AssertClose(direct.Position.X, helper.Value.Position.X);
+        AssertClose(direct.Position.Z, helper.Value.Position.Z);
+        AssertClose(direct.Rotation, helper.Value.Rotation);
+    }
+
+    [Fact]
+    public void FormationPointMovement_Gets_Single_PointOne_Anchor_Cid()
+    {
+        var formation = new Formation
+        {
+            Points = [
+                new FormationPoint { Cids = [100] },
+                new FormationPoint { Cids = [101] },
+            ],
+        };
+
+        var resolved = FormationPointMovement.TryGetPointOneAnchorCid(formation, null, out var cid, out var failure);
+
+        Assert.True(resolved, failure);
+        Assert.Equal(100UL, cid);
+    }
+
+    [Fact]
+    public void FormationPointMovement_Rejects_Ambiguous_PointOne_Anchor_Cid()
+    {
+        var formation = new Formation
+        {
+            Points = [
+                new FormationPoint { Cids = [100, 101] },
+                new FormationPoint { Cids = [102] },
+            ],
+        };
+
+        var resolved = FormationPointMovement.TryGetPointOneAnchorCid(formation, null, out _, out var failure);
+
+        Assert.False(resolved);
+        Assert.Contains("exactly one", failure);
+    }
+
+    [Fact]
+    public void FormationPointMovement_Builds_Assigned_Move_From_PointOne_Anchor()
+    {
+        var formation = new Formation
+        {
+            Points = [
+                new FormationPoint { Offset = new Vector3(5f, 0f, 5f), Angle = 45f, Cids = [100] },
+                new FormationPoint { Offset = new Vector3(5f, 0f, 7f), Angle = -45f, Cids = [101] },
+            ],
+        };
+
+        var move = FormationPointMovement.BuildAssignedPointOneAnchoredWorldMove(
+            formation,
+            destinationContentId: 101,
+            groups: null,
+            anchorWorldPosition: new Vector3(10f, 0f, 20f),
+            anchorWorldRotation: MathF.PI / 2f,
+            out var destinationPointIndex);
+
+        Assert.NotNull(move);
+        Assert.Equal(1, destinationPointIndex);
+        AssertClose(12f, move.Value.Position.X);
+        AssertClose(20f, move.Value.Position.Z);
+        AssertClose(0f, move.Value.Rotation);
+    }
+
     private static void AssertClose(float expected, float actual, float tolerance = 0.0001f) =>
         Assert.InRange(MathF.Abs(expected - actual), 0f, tolerance);
 }

--- a/MasterOfPuppetsTests/FormationImportTests.cs
+++ b/MasterOfPuppetsTests/FormationImportTests.cs
@@ -208,6 +208,88 @@ public class FormationImportTests {
         });
     }
 
+    [Fact]
+    public void FormationShareCode_RoundTripsFormationWithAssignments() {
+        var source = new Formation {
+            Name = "Shared Circle",
+            Points = [
+                new FormationPoint {
+                    Offset = new Vector3(1f, 2f, 3f),
+                    Angle = 45f,
+                    Cids = [100, 101],
+                    GroupIds = ["Group A"],
+                },
+                new FormationPoint {
+                    Offset = new Vector3(-1f, 0f, 2f),
+                    Angle = -90f,
+                    Cids = [102],
+                },
+            ],
+        };
+
+        var code = FormationShareCode.Export(source, includeAssignments: true);
+        var imported = FormationShareCode.TryImport(code, out var formation, out var error);
+
+        Assert.True(imported, error);
+        Assert.Equal("Shared Circle", formation.Name);
+        Assert.Equal(2, formation.Points.Count);
+        AssertClose(1f, formation.Points[0].Offset.X);
+        AssertClose(2f, formation.Points[0].Offset.Y);
+        AssertClose(3f, formation.Points[0].Offset.Z);
+        AssertClose(45f, formation.Points[0].Angle);
+        Assert.Equal([100UL, 101UL], formation.Points[0].Cids);
+        Assert.Equal(["Group A"], formation.Points[0].GroupIds);
+        Assert.Equal([102UL], formation.Points[1].Cids);
+    }
+
+    [Fact]
+    public void FormationShareCode_ExportWithoutAssignments_ClearsCidsAndGroups() {
+        var source = new Formation {
+            Name = "Shared Circle",
+            Points = [
+                new FormationPoint {
+                    Offset = new Vector3(1f, 0f, 3f),
+                    Angle = 45f,
+                    Cids = [100],
+                    GroupIds = ["Group A"],
+                },
+            ],
+        };
+
+        var code = FormationShareCode.Export(source, includeAssignments: false);
+        var imported = FormationShareCode.TryImport(code, out var formation, out var error);
+
+        Assert.True(imported, error);
+        var point = Assert.Single(formation.Points);
+        Assert.Empty(point.Cids);
+        Assert.Empty(point.GroupIds);
+        AssertClose(1f, point.Offset.X);
+        AssertClose(3f, point.Offset.Z);
+        AssertClose(45f, point.Angle);
+    }
+
+    [Fact]
+    public void FormationShareCode_RejectsInvalidCodeWithoutMutatingOutput() {
+        var imported = FormationShareCode.TryImport("not-a-formation-code", out var formation, out var error);
+
+        Assert.False(imported);
+        Assert.Contains("MOPF1:", error);
+        Assert.Empty(formation.Name);
+        Assert.Empty(formation.Points);
+    }
+
+    [Fact]
+    public void FormationShareCode_GetUniqueName_AppendsSuffixForDuplicateNames() {
+        var formations = new[] {
+            new Formation { Name = "Circle" },
+            new Formation { Name = "Circle (2)" },
+        };
+
+        var name = FormationShareCode.GetUniqueName("Circle", formations);
+
+        Assert.Equal("Circle (3)", name);
+    }
+
     private static BardToolboxFormationImport ReadBardToolboxImport() =>
         BardToolboxFormationImporter.ParseConfigJson(BardToolboxConfigJson);
 

--- a/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
+++ b/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
@@ -388,7 +388,7 @@ public class FormationMacroGeneratorTests {
                 UseFormationMoveCommand = true,
                 FormationMoveName = "Circle",
                 OriginContentId = 100,
-                FormationMoveArrivalMode = MovementArrivalMode.Precise,
+                FormationMoveMode = SimpleMovementMode.Precise,
                 FormationMoveAnchorMode = FormationMoveAnchorMode.Target,
             });
 
@@ -459,7 +459,7 @@ public class FormationMacroGeneratorTests {
                 Mode = FormationMacroGeneratorMode.Movement,
                 UseLocalFormationPointCommand = true,
                 FormationMoveName = "Circle",
-                FormationMoveArrivalMode = MovementArrivalMode.Precise,
+                FormationMoveMode = SimpleMovementMode.Precise,
                 FormationMoveAnchorMode = FormationMoveAnchorMode.Target,
             });
 

--- a/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
+++ b/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
@@ -402,6 +402,73 @@ public class FormationMacroGeneratorTests {
     }
 
     [Fact]
+    public void GenerateLoopMacro_ExistingFormationLocalPointMovement_EmitsPerPointGotoCommands() {
+        var formation = BuildEightPointFormation();
+
+        var result = FormationMacroGenerator.GenerateLoopMacroWithDiagnostics(
+            formation,
+            new FormationMacroGeneratorOptions {
+                Mode = FormationMacroGeneratorMode.Movement,
+                AnchorPointIndex = 0,
+                UseLocalFormationPointCommand = true,
+                FormationMoveName = "Circle",
+                OriginReference = "Origin Character@World",
+                TravelSecondsPerUnit = 1f,
+                GlobalDelaySeconds = 0f,
+            });
+
+        Assert.Empty(result.Warnings);
+        Assert.Equal(7, result.Macro.Commands.Count);
+        Assert.Equal([101UL], result.Macro.Commands[0].Cids);
+        Assert.Empty(result.Macro.Commands[0].GroupIds);
+
+        var lines = result.Macro.Commands[0].Actions.Split('\n');
+        Assert.Equal("/mopformationgoto \"Circle\" 2 anchor=\"Origin Character@World\" continuous", lines[0]);
+        Assert.Equal("/mopwait 1.00", lines[1]);
+        Assert.Equal("/mopformationgoto \"Circle\" 3 anchor=\"Origin Character@World\" continuous", lines[2]);
+        Assert.DoesNotContain("/mopformationmove", result.Macro.Commands[0].Actions);
+        Assert.EndsWith("/moploop", result.Macro.Commands[0].Actions);
+    }
+
+    [Fact]
+    public void GenerateLoopMacro_ExistingFormationLocalPointMovement_UsesPointOneAnchorEvenWhenConfiguredAnchorDiffers() {
+        var formation = BuildEightPointFormation();
+
+        var result = FormationMacroGenerator.GenerateLoopMacroWithDiagnostics(
+            formation,
+            new FormationMacroGeneratorOptions {
+                Mode = FormationMacroGeneratorMode.Movement,
+                AnchorPointIndex = 3,
+                UseLocalFormationPointCommand = true,
+                FormationMoveName = "Circle",
+                OriginReference = "Origin Character@World",
+            });
+
+        Assert.Equal(7, result.Macro.Commands.Count);
+        Assert.DoesNotContain(result.Macro.Commands, command => command.Cids.SequenceEqual([100UL]));
+        Assert.Contains(result.Macro.Commands, command => command.Cids.SequenceEqual([103UL]));
+    }
+
+    [Fact]
+    public void GenerateLoopMacro_ExistingFormationLocalPointMovement_EmitsTargetAndPreciseOptions() {
+        var formation = BuildEightPointFormation();
+
+        var result = FormationMacroGenerator.GenerateLoopMacroWithDiagnostics(
+            formation,
+            new FormationMacroGeneratorOptions {
+                Mode = FormationMacroGeneratorMode.Movement,
+                UseLocalFormationPointCommand = true,
+                FormationMoveName = "Circle",
+                FormationMoveArrivalMode = MovementArrivalMode.Precise,
+                FormationMoveAnchorMode = FormationMoveAnchorMode.Target,
+            });
+
+        var command = Assert.Single(result.Macro.Commands, command => command.Cids.SequenceEqual([101UL]));
+        var firstLine = command.Actions.Split('\n')[0];
+        Assert.Equal("/mopformationgoto \"Circle\" 2 anchor=target precise", firstLine);
+    }
+
+    [Fact]
     public void GenerateLoopMacro_ExistingFormationMovement_UsesMopScriptsTimingDefaults() {
         var formation = new Formation {
             Name = "Circle",

--- a/MasterOfPuppetsTests/MacroTests.cs
+++ b/MasterOfPuppetsTests/MacroTests.cs
@@ -170,7 +170,7 @@ public class MacroTests
         Assert.False(result.Reverse);
         Assert.Equal(1, result.Step);
         Assert.Equal(0, result.SequenceIndex);
-        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Continuous, result.MovementMode);
         Assert.Equal(FormationMoveAnchorMode.Self, result.AnchorMode);
         Assert.Equal(FormationAnchorKind.Self, result.Anchor.Kind);
     }
@@ -184,8 +184,30 @@ public class MacroTests
         Assert.True(result.Reverse);
         Assert.Equal(2, result.Step);
         Assert.Equal(3, result.SequenceIndex);
-        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Precise, result.MovementMode);
         Assert.Equal(FormationMoveAnchorMode.Self, result.AnchorMode);
+    }
+
+    [Theory]
+    [InlineData("continuous", SimpleMovementMode.Continuous)]
+    [InlineData("precise", SimpleMovementMode.Precise)]
+    [InlineData("forward", SimpleMovementMode.Forward)]
+    public void ParseFormationMoveCommandArgs_Accepts_All_Movement_Modes(string token, SimpleMovementMode expectedMode)
+    {
+        var result = MacroHandler.ParseFormationMoveCommandArgs($"\"Circle\" forward 1 0 {token}");
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedMode, result.MovementMode);
+    }
+
+    [Fact]
+    public void ParseFormationMoveCommandArgs_Rejects_Removed_Hybrid_Mode()
+    {
+        var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 hybrid");
+
+        Assert.NotNull(result);
+        Assert.Equal("hybrid", result.InvalidArgument);
+        Assert.Equal(FormationAnchorKind.Self, result.Anchor.Kind);
     }
 
     [Fact]
@@ -194,7 +216,7 @@ public class MacroTests
         var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 target");
 
         Assert.NotNull(result);
-        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Continuous, result.MovementMode);
         Assert.Equal(FormationMoveAnchorMode.Target, result.AnchorMode);
         Assert.Equal(FormationAnchorKind.Target, result.Anchor.Kind);
     }
@@ -207,9 +229,9 @@ public class MacroTests
 
         Assert.NotNull(targetLast);
         Assert.NotNull(targetFirst);
-        Assert.Equal(MovementArrivalMode.Precise, targetLast.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Precise, targetLast.MovementMode);
         Assert.Equal(FormationMoveAnchorMode.Target, targetLast.AnchorMode);
-        Assert.Equal(MovementArrivalMode.Precise, targetFirst.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Precise, targetFirst.MovementMode);
         Assert.Equal(FormationMoveAnchorMode.Target, targetFirst.AnchorMode);
     }
 
@@ -219,7 +241,7 @@ public class MacroTests
         var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 \"Anchor Character@World\"");
 
         Assert.NotNull(result);
-        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Continuous, result.MovementMode);
         Assert.Equal(FormationAnchorKind.Named, result.Anchor.Kind);
         Assert.Equal("Anchor Character@World", result.Anchor.Name);
         Assert.Null(result.InvalidArgument);
@@ -236,7 +258,7 @@ public class MacroTests
         Assert.Equal(MacroHandler.FormationGotoAnchorKind.Self, result.AnchorKind);
         Assert.Equal(FormationAnchorKind.Self, result.Anchor.Kind);
         Assert.Null(result.AnchorName);
-        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Continuous, result.MovementMode);
     }
 
     [Fact]
@@ -248,7 +270,7 @@ public class MacroTests
         Assert.Equal(2, result.PointIndex);
         Assert.Equal(MacroHandler.FormationGotoAnchorKind.Named, result.AnchorKind);
         Assert.Equal("Anchor Character@World", result.AnchorName);
-        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Precise, result.MovementMode);
     }
 
     [Fact]
@@ -271,7 +293,29 @@ public class MacroTests
         Assert.NotNull(result);
         Assert.Equal(FormationAnchorKind.Named, result.Anchor.Kind);
         Assert.Equal("Anchor Character@World", result.Anchor.Name);
-        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Precise, result.MovementMode);
+    }
+
+    [Theory]
+    [InlineData("continuous", SimpleMovementMode.Continuous)]
+    [InlineData("precise", SimpleMovementMode.Precise)]
+    [InlineData("forward", SimpleMovementMode.Forward)]
+    public void ParseFormationGotoCommandArgs_Accepts_All_Movement_Modes(string token, SimpleMovementMode expectedMode)
+    {
+        var result = MacroHandler.ParseFormationGotoCommandArgs($"\"Circle\" 4 target {token}");
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedMode, result.MovementMode);
+    }
+
+    [Fact]
+    public void ParseFormationGotoCommandArgs_Rejects_Removed_Hybrid_Mode()
+    {
+        var result = MacroHandler.ParseFormationGotoCommandArgs("\"Circle\" 4 target hybrid");
+
+        Assert.NotNull(result);
+        Assert.Equal("hybrid", result.InvalidArgument);
+        Assert.Equal(MacroHandler.FormationGotoAnchorKind.Target, result.AnchorKind);
     }
 
     [Fact]
@@ -299,7 +343,35 @@ public class MacroTests
             FormationAnchorReference.Default);
 
         Assert.Equal(FormationAnchorKind.Default, result.Anchor.Kind);
-        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+        Assert.Equal(SimpleMovementMode.Precise, result.MovementMode);
+    }
+
+    [Fact]
+    public void ParseFormationAnchorAndArrival_Preserves_Self_Anchor_For_Local_MopFormation()
+    {
+        var result = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            ["precise"],
+            FormationAnchorReference.Self);
+
+        Assert.Equal(FormationAnchorKind.Self, result.Anchor.Kind);
+        Assert.Equal(SimpleMovementMode.Precise, result.MovementMode);
+        Assert.Null(result.InvalidArgument);
+    }
+
+    [Fact]
+    public void ParseFormationAnchorAndArrival_Accepts_Target_And_Precise_In_Either_Order()
+    {
+        var targetLast = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            ["precise", "target"],
+            FormationAnchorReference.Self);
+        var targetFirst = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            ["target", "precise"],
+            FormationAnchorReference.Self);
+
+        Assert.Equal(FormationAnchorKind.Target, targetLast.Anchor.Kind);
+        Assert.Equal(SimpleMovementMode.Precise, targetLast.MovementMode);
+        Assert.Equal(FormationAnchorKind.Target, targetFirst.Anchor.Kind);
+        Assert.Equal(SimpleMovementMode.Precise, targetFirst.MovementMode);
     }
 
     [Fact]

--- a/MasterOfPuppetsTests/MacroTests.cs
+++ b/MasterOfPuppetsTests/MacroTests.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 
 using MasterOfPuppets;
+using MasterOfPuppets.Formations;
+using MasterOfPuppets.Movement;
+using MasterOfPuppets.Util;
 
 public class MacroTests
 {
@@ -167,8 +170,9 @@ public class MacroTests
         Assert.False(result.Reverse);
         Assert.Equal(1, result.Step);
         Assert.Equal(0, result.SequenceIndex);
-        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Continuous, result.ArrivalMode);
-        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Self, result.AnchorMode);
+        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(FormationMoveAnchorMode.Self, result.AnchorMode);
+        Assert.Equal(FormationAnchorKind.Self, result.Anchor.Kind);
     }
 
     [Fact]
@@ -180,8 +184,8 @@ public class MacroTests
         Assert.True(result.Reverse);
         Assert.Equal(2, result.Step);
         Assert.Equal(3, result.SequenceIndex);
-        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Precise, result.ArrivalMode);
-        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Self, result.AnchorMode);
+        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+        Assert.Equal(FormationMoveAnchorMode.Self, result.AnchorMode);
     }
 
     [Fact]
@@ -190,8 +194,9 @@ public class MacroTests
         var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 target");
 
         Assert.NotNull(result);
-        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Continuous, result.ArrivalMode);
-        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Target, result.AnchorMode);
+        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(FormationMoveAnchorMode.Target, result.AnchorMode);
+        Assert.Equal(FormationAnchorKind.Target, result.Anchor.Kind);
     }
 
     [Fact]
@@ -202,20 +207,108 @@ public class MacroTests
 
         Assert.NotNull(targetLast);
         Assert.NotNull(targetFirst);
-        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Precise, targetLast.ArrivalMode);
-        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Target, targetLast.AnchorMode);
-        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Precise, targetFirst.ArrivalMode);
-        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Target, targetFirst.AnchorMode);
+        Assert.Equal(MovementArrivalMode.Precise, targetLast.ArrivalMode);
+        Assert.Equal(FormationMoveAnchorMode.Target, targetLast.AnchorMode);
+        Assert.Equal(MovementArrivalMode.Precise, targetFirst.ArrivalMode);
+        Assert.Equal(FormationMoveAnchorMode.Target, targetFirst.AnchorMode);
     }
 
     [Fact]
-    public void ParseFormationMoveCommandArgs_Invalid_Argument_Falls_Back_To_Defaults()
+    public void ParseFormationMoveCommandArgs_Accepts_Named_Anchor()
     {
-        var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 careful");
+        var result = MacroHandler.ParseFormationMoveCommandArgs("\"Circle\" forward 1 0 \"Anchor Character@World\"");
 
         Assert.NotNull(result);
-        Assert.Equal(MasterOfPuppets.Movement.MovementArrivalMode.Continuous, result.ArrivalMode);
-        Assert.Equal(MasterOfPuppets.Formations.FormationMoveAnchorMode.Self, result.AnchorMode);
-        Assert.Equal("careful", result.InvalidArgument);
+        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+        Assert.Equal(FormationAnchorKind.Named, result.Anchor.Kind);
+        Assert.Equal("Anchor Character@World", result.Anchor.Name);
+        Assert.Null(result.InvalidArgument);
+    }
+
+    [Fact]
+    public void ParseFormationGotoCommandArgs_Defaults_To_Self_Continuous()
+    {
+        var result = MacroHandler.ParseFormationGotoCommandArgs("\"Circle\" 2");
+
+        Assert.NotNull(result);
+        Assert.Equal("Circle", result.FormationName);
+        Assert.Equal(1, result.PointIndex);
+        Assert.Equal(MacroHandler.FormationGotoAnchorKind.Self, result.AnchorKind);
+        Assert.Equal(FormationAnchorKind.Self, result.Anchor.Kind);
+        Assert.Null(result.AnchorName);
+        Assert.Equal(MovementArrivalMode.Continuous, result.ArrivalMode);
+    }
+
+    [Fact]
+    public void ParseFormationGotoCommandArgs_Accepts_Quoted_Named_Anchor()
+    {
+        var result = MacroHandler.ParseFormationGotoCommandArgs("\"Circle\" 3 anchor=\"Anchor Character@World\" precise");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.PointIndex);
+        Assert.Equal(MacroHandler.FormationGotoAnchorKind.Named, result.AnchorKind);
+        Assert.Equal("Anchor Character@World", result.AnchorName);
+        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+    }
+
+    [Fact]
+    public void ParseFormationGotoCommandArgs_Accepts_Target_And_Self_Anchors()
+    {
+        var target = MacroHandler.ParseFormationGotoCommandArgs("\"Circle\" 4 target");
+        var self = MacroHandler.ParseFormationGotoCommandArgs("\"Circle\" 4 anchor=self");
+
+        Assert.NotNull(target);
+        Assert.NotNull(self);
+        Assert.Equal(MacroHandler.FormationGotoAnchorKind.Target, target.AnchorKind);
+        Assert.Equal(MacroHandler.FormationGotoAnchorKind.Self, self.AnchorKind);
+    }
+
+    [Fact]
+    public void ParseFormationGotoCommandArgs_Accepts_Bare_Named_Anchor()
+    {
+        var result = MacroHandler.ParseFormationGotoCommandArgs("\"Circle\" 4 \"Anchor Character@World\" precise");
+
+        Assert.NotNull(result);
+        Assert.Equal(FormationAnchorKind.Named, result.Anchor.Kind);
+        Assert.Equal("Anchor Character@World", result.Anchor.Name);
+        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+    }
+
+    [Fact]
+    public void ParseChatArgs_Parses_Mopformation_Without_Slash()
+    {
+        var result = ArgumentParser.ParseChatArgs("mopformation \"Tight Circle\" target precise");
+
+        Assert.Equal(["mopformation", "Tight Circle", "target", "precise"], result);
+    }
+
+    [Fact]
+    public void ParseChatArgs_Does_Not_Treat_Slash_MopFormation_As_ChatSync_Command()
+    {
+        var result = ArgumentParser.ParseChatArgs("/mop formation \"Tight Circle\"");
+
+        Assert.Single(result);
+        Assert.NotEqual("mopformation", result[0]);
+    }
+
+    [Fact]
+    public void ParseFormationAnchorAndArrival_Defaults_To_PointOne_Anchor_For_Chat()
+    {
+        var result = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            ["precise"],
+            FormationAnchorReference.Default);
+
+        Assert.Equal(FormationAnchorKind.Default, result.Anchor.Kind);
+        Assert.Equal(MovementArrivalMode.Precise, result.ArrivalMode);
+    }
+
+    [Fact]
+    public void ParseFormationGotoCommandArgs_Rejects_Invalid_Point_Number()
+    {
+        var result = MacroHandler.ParseFormationGotoCommandArgs("\"Circle\" 0");
+
+        Assert.NotNull(result);
+        Assert.Equal(-1, result.PointIndex);
+        Assert.Equal("0", result.InvalidArgument);
     }
 }

--- a/MasterOfPuppetsTests/SimpleInputMovementTests.cs
+++ b/MasterOfPuppetsTests/SimpleInputMovementTests.cs
@@ -7,30 +7,30 @@ using Xunit;
 public class SimpleInputMovementTests {
     [Fact]
     public void GetArrivalState_Runs_When_Outside_Walk_Buffer() {
-        var state = SimpleInputMovement.GetArrivalState(distance: 0.61f, precision: 0.1f);
+        var state = SimpleInputMovement.GetArrivalState(distance: 0.61f, precision: 0.1f, SimpleMovementMode.Forward);
 
         Assert.Equal(ArrivalMovementState.Run, state);
     }
 
     [Fact]
     public void GetArrivalState_Walks_When_Inside_Walk_Buffer_But_Outside_Stop_Radius() {
-        var state = SimpleInputMovement.GetArrivalState(distance: 0.5f, precision: 0.1f);
+        var state = SimpleInputMovement.GetArrivalState(distance: 0.5f, precision: 0.1f, SimpleMovementMode.Forward);
 
         Assert.Equal(ArrivalMovementState.Walk, state);
     }
 
     [Fact]
     public void GetArrivalState_Stops_When_Inside_Precision_Radius() {
-        var state = SimpleInputMovement.GetArrivalState(distance: 0.09f, precision: 0.1f);
+        var state = SimpleInputMovement.GetArrivalState(distance: 0.09f, precision: 0.1f, SimpleMovementMode.Forward);
 
         Assert.Equal(ArrivalMovementState.Stop, state);
     }
 
     [Fact]
     public void GetArrivalState_Uses_Configured_Precision() {
-        Assert.Equal(ArrivalMovementState.Stop, SimpleInputMovement.GetArrivalState(distance: 0.24f, precision: 0.25f));
-        Assert.Equal(ArrivalMovementState.Walk, SimpleInputMovement.GetArrivalState(distance: 0.7f, precision: 0.25f));
-        Assert.Equal(ArrivalMovementState.Run, SimpleInputMovement.GetArrivalState(distance: 0.76f, precision: 0.25f));
+        Assert.Equal(ArrivalMovementState.Stop, SimpleInputMovement.GetArrivalState(distance: 0.24f, precision: 0.25f, SimpleMovementMode.Forward));
+        Assert.Equal(ArrivalMovementState.Walk, SimpleInputMovement.GetArrivalState(distance: 0.7f, precision: 0.25f, SimpleMovementMode.Forward));
+        Assert.Equal(ArrivalMovementState.Run, SimpleInputMovement.GetArrivalState(distance: 0.76f, precision: 0.25f, SimpleMovementMode.Forward));
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class SimpleInputMovementTests {
         var state = SimpleInputMovement.GetArrivalState(
             distance: 0.5f,
             precision: 0.1f,
-            MovementArrivalMode.Continuous);
+            SimpleMovementMode.Continuous);
 
         Assert.Equal(ArrivalMovementState.Run, state);
     }
@@ -48,9 +48,16 @@ public class SimpleInputMovementTests {
         var state = SimpleInputMovement.GetArrivalState(
             distance: 0.09f,
             precision: 0.1f,
-            MovementArrivalMode.Continuous);
+            SimpleMovementMode.Continuous);
 
         Assert.Equal(ArrivalMovementState.Stop, state);
+    }
+
+    [Fact]
+    public void GetArrivalState_Precise_Uses_Forward_Walk_Radius() {
+        Assert.Equal(ArrivalMovementState.Run, SimpleInputMovement.GetArrivalState(distance: 0.61f, precision: 0.1f, SimpleMovementMode.Precise));
+        Assert.Equal(ArrivalMovementState.Walk, SimpleInputMovement.GetArrivalState(distance: 0.6f, precision: 0.1f, SimpleMovementMode.Precise));
+        Assert.Equal(ArrivalMovementState.Stop, SimpleInputMovement.GetArrivalState(distance: 0.1f, precision: 0.1f, SimpleMovementMode.Precise));
     }
 
     [Fact]

--- a/MasterOfPuppetsTests/SimpleInputMovementTests.cs
+++ b/MasterOfPuppetsTests/SimpleInputMovementTests.cs
@@ -61,6 +61,64 @@ public class SimpleInputMovementTests {
     }
 
     [Fact]
+    public void UpdateContinuousProgress_Completes_Inside_Precision() {
+        var progress = SimpleInputMovement.UpdateContinuousProgress(
+            distance: 0.09f,
+            precision: 0.1f,
+            previousDistance: 0.2f,
+            hasApproached: true);
+
+        Assert.True(progress.Complete);
+    }
+
+    [Fact]
+    public void UpdateContinuousProgress_Keeps_Running_While_Approaching() {
+        var progress = SimpleInputMovement.UpdateContinuousProgress(
+            distance: 1.5f,
+            precision: 0.1f,
+            previousDistance: 2f,
+            hasApproached: false);
+
+        Assert.False(progress.Complete);
+        Assert.True(progress.HasApproached);
+    }
+
+    [Fact]
+    public void UpdateContinuousProgress_Completes_After_Passing_Closest_Approach() {
+        var progress = SimpleInputMovement.UpdateContinuousProgress(
+            distance: 1.61f,
+            precision: 0.1f,
+            previousDistance: 1.5f,
+            hasApproached: true);
+
+        Assert.True(progress.Complete);
+    }
+
+    [Fact]
+    public void UpdateContinuousProgress_Does_Not_Complete_On_First_Large_Sample() {
+        var progress = SimpleInputMovement.UpdateContinuousProgress(
+            distance: 5f,
+            precision: 0.1f,
+            previousDistance: null,
+            hasApproached: false);
+
+        Assert.False(progress.Complete);
+        Assert.False(progress.HasApproached);
+    }
+
+    [Fact]
+    public void UpdateContinuousProgress_Does_Not_Complete_On_Increase_Before_Approach() {
+        var progress = SimpleInputMovement.UpdateContinuousProgress(
+            distance: 6f,
+            precision: 0.1f,
+            previousDistance: 5f,
+            hasApproached: false);
+
+        Assert.False(progress.Complete);
+        Assert.False(progress.HasApproached);
+    }
+
+    [Fact]
     public void ProgressTracker_Does_Not_Report_Stuck_On_First_Sample() {
         var tracker = new SimpleMovementProgressTracker();
 


### PR DESCRIPTION
Add mode for local movement instead of constant broadcast for formations with /mopformationgoto

Use this as the foundation for the chat sync command "mopformation" so that formations can be executed across machines using chat

Also add ArrivePreciseMovementStrategy which uses movement settling and hysteresis (game programming movement techniques) for more precise positioning/stopping.