### PR TITLE
/mopformationgoto anchoring and target macro error spam fix

### DIFF
--- a/MasterOfPuppets/Formations/FormationAnchorReference.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorReference.cs
@@ -12,6 +12,15 @@ public enum FormationAnchorKind {
     Named,
 }
 
+public enum FormationAnchorFailureKind {
+    None,
+    NoTargetSelected,
+    AnchorNameEmpty,
+    AnchorNotVisible,
+    ConfigurationError,
+    Unsupported,
+}
+
 public sealed record FormationAnchorReference(FormationAnchorKind Kind, string? Name = null) {
     public static readonly FormationAnchorReference Default = new(FormationAnchorKind.Default);
     public static readonly FormationAnchorReference Self = new(FormationAnchorKind.Self);

--- a/MasterOfPuppets/Formations/FormationAnchorResolver.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorResolver.cs
@@ -16,19 +16,22 @@ public static class FormationAnchorResolver {
         Formation formation,
         FormationAnchorReference anchor,
         out FormationResolvedAnchor resolved,
-        out string failureReason) {
+        out string failureReason,
+        out FormationAnchorFailureKind failureKind) {
         resolved = new FormationResolvedAnchor(default, default);
         failureReason = string.Empty;
+        failureKind = FormationAnchorFailureKind.None;
 
         var player = DalamudApi.ObjectTable.LocalPlayer;
         if (player == null) {
             failureReason = "local player is unavailable";
+            failureKind = FormationAnchorFailureKind.ConfigurationError;
             return false;
         }
 
         switch (anchor.Kind) {
             case FormationAnchorKind.Default:
-                return TryResolvePointOneAnchor(plugin, formation, out resolved, out failureReason);
+                return TryResolvePointOneAnchor(plugin, formation, out resolved, out failureReason, out failureKind);
             case FormationAnchorKind.Self:
                 resolved = new FormationResolvedAnchor(
                     player.Position,
@@ -39,6 +42,7 @@ public static class FormationAnchorResolver {
             case FormationAnchorKind.Target:
                 if (player.TargetObject == null) {
                     failureReason = "no target selected";
+                    failureKind = FormationAnchorFailureKind.NoTargetSelected;
                     return false;
                 }
 
@@ -49,9 +53,10 @@ public static class FormationAnchorResolver {
                     player.TargetObject.Name.TextValue);
                 return true;
             case FormationAnchorKind.Named:
-                return TryResolveNamed(anchor.Name ?? string.Empty, out resolved, out failureReason);
+                return TryResolveNamed(anchor.Name ?? string.Empty, out resolved, out failureReason, out failureKind);
             default:
                 failureReason = $"unsupported anchor kind {anchor.Kind}";
+                failureKind = FormationAnchorFailureKind.Unsupported;
                 return false;
         }
     }
@@ -59,12 +64,15 @@ public static class FormationAnchorResolver {
     public static bool TryResolveNamed(
         string objectName,
         out FormationResolvedAnchor resolved,
-        out string failureReason) {
+        out string failureReason,
+        out FormationAnchorFailureKind failureKind) {
         resolved = new FormationResolvedAnchor(default, default);
         failureReason = string.Empty;
+        failureKind = FormationAnchorFailureKind.None;
 
         if (string.IsNullOrWhiteSpace(objectName)) {
             failureReason = "anchor name is empty";
+            failureKind = FormationAnchorFailureKind.AnchorNameEmpty;
             return false;
         }
 
@@ -90,6 +98,7 @@ public static class FormationAnchorResolver {
 
         if (match == null) {
             failureReason = $"anchor not visible: \"{objectName}\"";
+            failureKind = FormationAnchorFailureKind.AnchorNotVisible;
             return false;
         }
 
@@ -105,15 +114,20 @@ public static class FormationAnchorResolver {
         Plugin plugin,
         Formation formation,
         out FormationResolvedAnchor resolved,
-        out string failureReason) {
+        out string failureReason,
+        out FormationAnchorFailureKind failureKind) {
         resolved = new FormationResolvedAnchor(default, default);
-        if (!FormationPointMovement.TryGetPointOneAnchorCid(formation, plugin.Config.CidsGroups, out var anchorCid, out failureReason))
+        failureKind = FormationAnchorFailureKind.None;
+        if (!FormationPointMovement.TryGetPointOneAnchorCid(formation, plugin.Config.CidsGroups, out var anchorCid, out failureReason)) {
+            failureKind = FormationAnchorFailureKind.ConfigurationError;
             return false;
+        }
 
         if (anchorCid == DalamudApi.PlayerState.ContentId) {
             var player = DalamudApi.ObjectTable.LocalPlayer;
             if (player == null) {
                 failureReason = "local point-1 anchor is unavailable";
+                failureKind = FormationAnchorFailureKind.ConfigurationError;
                 return false;
             }
 
@@ -124,10 +138,11 @@ public static class FormationAnchorResolver {
         var configuredName = plugin.Config.Characters.FirstOrDefault(character => character.Cid == anchorCid)?.Name;
         if (string.IsNullOrWhiteSpace(configuredName)) {
             failureReason = $"point 1 character {anchorCid} is not configured";
+            failureKind = FormationAnchorFailureKind.ConfigurationError;
             return false;
         }
 
-        if (TryResolveNamed(configuredName, out resolved, out failureReason)) {
+        if (TryResolveNamed(configuredName, out resolved, out failureReason, out failureKind)) {
             resolved = resolved with { ContentId = anchorCid };
             return true;
         }

--- a/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
+++ b/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
@@ -16,8 +16,8 @@ public static class FormationLocalMovementExecutor {
         if (!TryGetFormation(plugin, formationName, logPrefix, out var formation))
             return false;
 
-        if (!FormationAnchorResolver.TryResolve(plugin, formation, anchor, out var resolvedAnchor, out var anchorFailure)) {
-            DalamudApi.PluginLog.Warning($"[{logPrefix}] {anchorFailure}");
+        if (!FormationAnchorResolver.TryResolve(plugin, formation, anchor, out var resolvedAnchor, out var anchorFailure, out var failureKind)) {
+            LogAnchorFailure(logPrefix, anchorFailure, failureKind);
             return false;
         }
 
@@ -52,8 +52,8 @@ public static class FormationLocalMovementExecutor {
             return true;
         }
 
-        if (!FormationAnchorResolver.TryResolve(plugin, formation, anchor, out var resolvedAnchor, out var anchorFailure)) {
-            DalamudApi.PluginLog.Warning($"[{logPrefix}] {anchorFailure}");
+        if (!FormationAnchorResolver.TryResolve(plugin, formation, anchor, out var resolvedAnchor, out var anchorFailure, out var failureKind)) {
+            LogAnchorFailure(logPrefix, anchorFailure, failureKind);
             return false;
         }
 
@@ -118,4 +118,21 @@ public static class FormationLocalMovementExecutor {
         DalamudApi.PluginLog.Warning($"[{logPrefix}] formation not found: \"{formationName}\"");
         return false;
     }
+
+    private static void LogAnchorFailure(
+        string logPrefix,
+        string anchorFailure,
+        FormationAnchorFailureKind failureKind) {
+        var message = $"[{logPrefix}] {anchorFailure}";
+        if (IsTransientAnchorFailure(failureKind)) {
+            DalamudApi.PluginLog.Debug(message);
+        } else {
+            DalamudApi.PluginLog.Warning(message);
+        }
+    }
+
+    public static bool IsTransientAnchorFailure(FormationAnchorFailureKind failureKind) =>
+        failureKind is FormationAnchorFailureKind.NoTargetSelected
+            or FormationAnchorFailureKind.AnchorNameEmpty
+            or FormationAnchorFailureKind.AnchorNotVisible;
 }

--- a/MasterOfPuppets/Game/Login/AutoLoginManager.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginManager.cs
@@ -39,6 +39,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
     private string _pendingCharacterName = string.Empty;
     private int _pendingCharacterIndex = -1;
     private bool _hasPendingCharacterSelection;
+    private AutoLoginCharacterMatch? _pendingCharacterMatch;
     private bool _loggedWorldSelectorSnapshot;
     private bool _loggedCharacterListSnapshot;
     private bool _loggedDirectCharacterListMismatch;
@@ -230,14 +231,13 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             return false;
 
         var lobbyEntries = ReadLobbyEntries();
-        LogCharacterListSnapshot(visibleCharacters, lobbyEntries);
+        LogCharacterListSnapshot(CurrentWorldLabel, visibleCharacters, lobbyEntries);
 
-        if (!AutoLoginPlanner.TryResolveDirectCharacterListTarget(
+        if (!AutoLoginPlanner.TryResolveDirectCharacterListMatch(
                 _candidates,
                 lobbyEntries,
                 visibleCharacters,
-                out var target,
-                out var characterIndex,
+                out var match,
                 out var reason)) {
             if (!_loggedDirectCharacterListMismatch) {
                 _loggedDirectCharacterListMismatch = true;
@@ -248,9 +248,9 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             return false;
         }
 
-        _target = target;
+        _target = match.Target;
         DalamudApi.PluginLog.Information(
-            $"[AutoLogin] Character list already open; checking resolved character {_target.Value.CharacterName} at index {characterIndex}. Resolution: {reason}.");
+            $"[AutoLogin] Character list already open; {FormatCharacterMatch(match)}.");
         SetState(LoginState.WaitingCharacterList);
         return true;
     }
@@ -275,29 +275,35 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         if (visibleCharacters.Count == 0)
             return;
 
-        LogCharacterListSnapshot(visibleCharacters, ReadLobbyEntries());
+        var lobbyEntries = ReadLobbyEntries();
+        LogCharacterListSnapshot(CurrentWorldLabel, visibleCharacters, lobbyEntries);
 
         if (!_hasPendingCharacterSelection ||
             _pendingCharacterIndex < 0 ||
             _pendingCharacterIndex >= visibleCharacters.Count ||
             !visibleCharacters[_pendingCharacterIndex].Equals(_pendingCharacterName, StringComparison.InvariantCultureIgnoreCase)) {
-            if (!AutoLoginPlanner.TryFindVisibleCandidate(
+            if (!AutoLoginPlanner.TryFindVisibleCandidateMatch(
                     _candidates,
+                    lobbyEntries,
                     visibleCharacters,
-                    out _pendingCharacterName,
-                    out _pendingCharacterIndex)) {
+                    CurrentWorldLabel,
+                    out var match,
+                    out var reason)) {
                 DalamudApi.PluginLog.Information(
-                    $"[AutoLogin] No whitelisted character visible on {CurrentWorldLabel}. Checked: {string.Join(", ", _candidates.Select(c => c.Name))}. Visible: {string.Join(", ", visibleCharacters)}.");
+                    $"[AutoLogin] No whitelisted character visible on {CurrentWorldLabel}. Reason: {reason}. Checked: {string.Join(", ", _candidates.Select(FormatCandidate))}. Visible: {string.Join(", ", visibleCharacters)}. Lobby: {FormatLobbySnapshot(lobbyEntries)}.");
                 SelectNextWorldCandidate();
                 return;
             }
 
-            _target = new AutoLoginTarget(_pendingCharacterName, _target?.WorldName ?? string.Empty);
+            _pendingCharacterName = match.Target.CharacterName;
+            _pendingCharacterIndex = match.Index;
+            _pendingCharacterMatch = match;
+            _target = match.Target;
             _hasPendingCharacterSelection = true;
             _stateDelayMs = Random.Shared.Next(CharacterSelectDelayMinMs, CharacterSelectDelayMaxMs + 1);
             _stateTimer.Restart();
             DalamudApi.PluginLog.Debug(
-                $"[AutoLogin] Found {_pendingCharacterName} at index {_pendingCharacterIndex}; waiting {_stateDelayMs}ms before character selection.");
+                $"[AutoLogin] Found {_pendingCharacterName}; {FormatCharacterMatch(match)}; waiting {_stateDelayMs}ms before character selection.");
             return;
         }
 
@@ -309,14 +315,14 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
 
         var selected = SendTitleAction("_CharaSelectListMenu", 3, 29, 3, 0, 3, _pendingCharacterIndex);
         DalamudApi.PluginLog.Debug(
-            $"[AutoLogin] Character callback success={selected}; checked={string.Join(", ", _candidates.Select(c => c.Name))}; visible={string.Join(", ", visibleCharacters)}; selected={_pendingCharacterName}; index={_pendingCharacterIndex}.");
+            $"[AutoLogin] Character callback success={selected}; checked={string.Join(", ", _candidates.Select(FormatCandidate))}; visible={string.Join(", ", visibleCharacters)}; selected={_pendingCharacterName}; index={_pendingCharacterIndex}; match={FormatPendingCharacterMatch()}.");
         if (selected) {
             DalamudApi.PluginLog.Information(
-                $"[AutoLogin] Selected character {_pendingCharacterName} at index {_pendingCharacterIndex} after {_stateTimer.ElapsedMilliseconds}ms.");
+                $"[AutoLogin] Selected character {_pendingCharacterName} at index {_pendingCharacterIndex} after {_stateTimer.ElapsedMilliseconds}ms. Match: {FormatPendingCharacterMatch()}.");
             SetState(LoginState.ConfirmingLogin);
         } else {
             DalamudApi.PluginLog.Warning(
-                $"[AutoLogin] No checked character was visible. Checked: {string.Join(", ", _candidates.Select(c => c.Name))}. Visible: {string.Join(", ", visibleCharacters)}.");
+                $"[AutoLogin] No checked character was visible. Checked: {string.Join(", ", _candidates.Select(FormatCandidate))}. Visible: {string.Join(", ", visibleCharacters)}. Match: {FormatPendingCharacterMatch()}.");
             Stop();
         }
     }
@@ -353,6 +359,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             }
 
             _target = new AutoLoginTarget(string.Empty, world);
+            _loggedCharacterListSnapshot = false;
             DalamudApi.PluginLog.Information(
                 $"[AutoLogin] Checking whitelisted characters on {world} at world index {selectedWorldIndex} ({_worldIndex}/{_worldQueue.Count}).");
             _waitingForWorldSelectionSettle = true;
@@ -412,13 +419,13 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             $"[AutoLogin] World selector snapshot: source={(snapshot.UsedAddonWorldEntries ? "WorldEntries" : "StringArrayFallback")}; selectedWorldIndex={snapshot.SelectedWorldIndex}; worlds={snapshot.Worlds.Count} [{FormatWorldSelectorSnapshot(snapshot.Worlds)}]; lobbyEntries={lobbyEntries.Count} [{FormatLobbySnapshot(lobbyEntries)}].");
     }
 
-    private void LogCharacterListSnapshot(IReadOnlyList<string> characterNames, IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) {
+    private void LogCharacterListSnapshot(string selectedWorldName, IReadOnlyList<string> characterNames, IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) {
         if (_loggedCharacterListSnapshot)
             return;
 
         _loggedCharacterListSnapshot = true;
         DalamudApi.PluginLog.Debug(
-            $"[AutoLogin] Character list snapshot: characters={characterNames.Count} [{Preview(characterNames)}]; lobbyEntries={lobbyEntries.Count} [{FormatLobbySnapshot(lobbyEntries)}].");
+            $"[AutoLogin] Character list decision input: selectedWorld=\"{LogValue(selectedWorldName)}\"; candidates=[{string.Join(", ", _candidates.Select(FormatCandidate))}]; characters={characterNames.Count} [{Preview(characterNames)}]; lobbyEntries={lobbyEntries.Count} [{FormatLobbySnapshot(lobbyEntries)}].");
     }
 
     private static string FormatAddonState(string addonName) {
@@ -487,6 +494,19 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             ? $"{candidate.Name}({candidate.ContentId})"
             : $"{candidate.Name}@{candidate.HomeWorldName}({candidate.ContentId})";
 
+    private string FormatPendingCharacterMatch() =>
+        _pendingCharacterMatch == null
+            ? $"method=<unknown>; selectedWorld=\"{LogValue(CurrentWorldLabel)}\""
+            : FormatCharacterMatch(_pendingCharacterMatch.Value);
+
+    private static string FormatCharacterMatch(AutoLoginCharacterMatch match) =>
+        $"method={match.Confidence}; candidate={FormatCandidate(match.Candidate)}; target={FormatTarget(match.Target)}; visibleIndex={match.Index}; reason=\"{LogValue(match.Reason)}\"";
+
+    private static string FormatTarget(AutoLoginTarget target) =>
+        string.IsNullOrWhiteSpace(target.WorldName)
+            ? $"\"{LogValue(target.CharacterName)}\""
+            : $"\"{LogValue(target.CharacterName)}@{LogValue(target.WorldName)}\"";
+
     private List<AutoLoginCandidate> GetLoginCandidates() {
         return AutoLoginPlanner.BuildCandidates(_plugin.Config.Characters);
     }
@@ -523,6 +543,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         _pendingCharacterName = string.Empty;
         _pendingCharacterIndex = -1;
         _hasPendingCharacterSelection = false;
+        _pendingCharacterMatch = null;
         _stateDelayMs = 0;
     }
 

--- a/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
@@ -47,6 +47,20 @@ public readonly record struct AutoLoginWorldQueueResult(List<string> Worlds, Lis
 
 public readonly record struct AutoLoginTarget(string CharacterName, string WorldName);
 
+public enum AutoLoginMatchConfidence {
+    None,
+    ContentId,
+    NameAndHomeWorld,
+    NameOnConfiguredHomeWorld,
+}
+
+public readonly record struct AutoLoginCharacterMatch(
+    AutoLoginCandidate Candidate,
+    AutoLoginTarget Target,
+    int Index,
+    AutoLoginMatchConfidence Confidence,
+    string Reason);
+
 public static class AutoLoginPlanner {
     public static List<AutoLoginCandidate> BuildCandidates(IEnumerable<Character> characters) {
         return characters
@@ -88,7 +102,10 @@ public static class AutoLoginPlanner {
         foreach (var candidate in candidates) {
             var entry = FindCandidateEntry(candidate, lobbyEntries);
             if (entry == null) {
-                diagnostics.Add($"No lobby current-world entry for {FormatCandidate(candidate)}.");
+                var sameNameEntries = FindSameNameEntries(candidate, lobbyEntries);
+                diagnostics.Add(sameNameEntries.Count == 0
+                    ? $"No lobby current-world entry for {FormatCandidate(candidate)}."
+                    : $"Ignored same-name lobby entries for {FormatCandidate(candidate)}: no content ID or home-world confirmation. Entries: {FormatLobbyEntries(sameNameEntries)}.");
                 continue;
             }
 
@@ -133,58 +150,148 @@ public static class AutoLoginPlanner {
         out AutoLoginTarget target,
         out int index,
         out string reason) {
+        if (TryResolveDirectCharacterListMatch(candidates, lobbyEntries, visibleCharacters, out var match, out reason)) {
+            target = match.Target;
+            index = match.Index;
+            return true;
+        }
+
         target = default;
         index = -1;
+        return false;
+    }
+
+    public static bool TryResolveDirectCharacterListMatch(
+        IReadOnlyList<AutoLoginCandidate> candidates,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
+        IReadOnlyList<string> visibleCharacters,
+        out AutoLoginCharacterMatch match,
+        out string reason) {
+        if (TryResolveVisibleCandidate(
+                candidates,
+                lobbyEntries,
+                visibleCharacters,
+                selectedWorldName: string.Empty,
+                allowConfiguredHomeWorldFallback: false,
+                out match,
+                out reason)) {
+            return true;
+        }
+
+        match = default;
+        return false;
+    }
+
+    public static bool TryFindVisibleCandidate(
+        IReadOnlyList<AutoLoginCandidate> candidates,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
+        IReadOnlyList<string> visibleCharacters,
+        string selectedWorldName,
+        out string characterName,
+        out int index,
+        out string reason) {
+        if (TryFindVisibleCandidateMatch(
+                candidates,
+                lobbyEntries,
+                visibleCharacters,
+                selectedWorldName,
+                out var match,
+                out reason)) {
+            characterName = match.Target.CharacterName;
+            index = match.Index;
+            return true;
+        }
+
+        characterName = string.Empty;
+        index = -1;
+        return false;
+    }
+
+    public static bool TryFindVisibleCandidateMatch(
+        IReadOnlyList<AutoLoginCandidate> candidates,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
+        IReadOnlyList<string> visibleCharacters,
+        string selectedWorldName,
+        out AutoLoginCharacterMatch match,
+        out string reason) {
+        if (TryResolveVisibleCandidate(
+                candidates,
+                lobbyEntries,
+                visibleCharacters,
+                selectedWorldName,
+                allowConfiguredHomeWorldFallback: true,
+                out match,
+                out reason)) {
+            return true;
+        }
+
+        match = default;
+        return false;
+    }
+
+    public static bool TryResolveVisibleCandidate(
+        IReadOnlyList<AutoLoginCandidate> candidates,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
+        IReadOnlyList<string> visibleCharacters,
+        string selectedWorldName,
+        bool allowConfiguredHomeWorldFallback,
+        out AutoLoginCharacterMatch match,
+        out string reason) {
+        match = default;
 
         if (candidates.Count == 0) {
             reason = "no enabled auto-login candidates were configured";
             return false;
         }
 
+        var skipReasons = new List<string>();
         for (var i = 0; i < visibleCharacters.Count; i++) {
-            var candidate = FindCandidateByVisibleName(candidates, visibleCharacters[i]);
-            if (candidate == null)
-                continue;
+            var visibleName = visibleCharacters[i];
+            foreach (var candidate in candidates.Where(candidate =>
+                         candidate.Name.Equals(visibleName, StringComparison.InvariantCultureIgnoreCase))) {
+                var entry = FindCandidateEntry(candidate, lobbyEntries);
+                if (entry != null && IsConfirmedCandidate(candidate, entry.Value, out var confidence, out var confirmationReason)) {
+                    var worldName = !string.IsNullOrWhiteSpace(entry.Value.CurrentWorldName)
+                        ? entry.Value.CurrentWorldName
+                        : selectedWorldName;
+                    var target = new AutoLoginTarget(candidate.Name, worldName);
+                    match = new AutoLoginCharacterMatch(candidate, target, i, confidence, confirmationReason);
+                    reason = confirmationReason;
+                    return true;
+                }
 
-            var entry = FindCandidateEntry(candidate.Value, lobbyEntries);
-            var worldName = !string.IsNullOrWhiteSpace(entry?.CurrentWorldName)
-                ? entry.Value.CurrentWorldName
-                : string.Empty;
-            target = new AutoLoginTarget(candidate.Value.Name, worldName);
-            index = i;
-            reason = entry == null
-                ? lobbyEntries.Count == 0
-                    ? $"lobby data was unavailable; resolved visible whitelisted character '{candidate.Value.Name}'"
-                    : $"resolved visible whitelisted character '{candidate.Value.Name}' without lobby confirmation"
-                : string.IsNullOrWhiteSpace(entry.Value.CurrentWorldName)
-                    ? $"resolved visible whitelisted character '{candidate.Value.Name}' from lobby data without current world"
-                    : $"resolved visible whitelisted character '{candidate.Value.Name}' from lobby data";
-            return true;
+                if (entry != null) {
+                    skipReasons.Add($"skipped visible '{visibleName}': lobby entry did not match configured identity for {FormatCandidate(candidate)}. Entry: {FormatLobbyEntry(entry.Value)}");
+                    continue;
+                }
+
+                var sameNameEntries = FindSameNameEntries(candidate, lobbyEntries);
+                if (sameNameEntries.Count > 0) {
+                    skipReasons.Add($"skipped visible '{visibleName}': same-name lobby entries did not match configured identity for {FormatCandidate(candidate)}. Entries: {FormatLobbyEntries(sameNameEntries)}");
+                    continue;
+                }
+
+                if (allowConfiguredHomeWorldFallback &&
+                    !string.IsNullOrWhiteSpace(candidate.HomeWorldName) &&
+                    candidate.HomeWorldName.Equals(selectedWorldName, StringComparison.InvariantCultureIgnoreCase)) {
+                    var target = new AutoLoginTarget(candidate.Name, selectedWorldName);
+                    reason = $"resolved visible whitelisted character '{candidate.Name}' on configured home world '{selectedWorldName}' without lobby confirmation";
+                    match = new AutoLoginCharacterMatch(candidate, target, i, AutoLoginMatchConfidence.NameOnConfiguredHomeWorld, reason);
+                    return true;
+                }
+
+                skipReasons.Add(
+                    string.IsNullOrWhiteSpace(candidate.HomeWorldName)
+                        ? $"skipped visible '{visibleName}': no lobby confirmation and configured home world is unknown for {FormatCandidate(candidate)}"
+                        : $"skipped visible '{visibleName}': no lobby confirmation and selected world '{selectedWorldName}' is not configured home world '{candidate.HomeWorldName}'");
+            }
         }
 
-        reason = lobbyEntries.Count == 0
-            ? "lobby data was unavailable and no configured character was visible"
-            : "no visible whitelisted character matched the configured whitelist";
-        return false;
-    }
-
-    public static bool TryFindVisibleCandidate(
-        IReadOnlyList<AutoLoginCandidate> candidates,
-        IReadOnlyList<string> visibleCharacters,
-        out string characterName,
-        out int index) {
-        var candidateNames = candidates.Select(c => c.Name).ToHashSet(StringComparer.InvariantCultureIgnoreCase);
-        index = -1;
-        for (var i = 0; i < visibleCharacters.Count; i++) {
-            if (!candidateNames.Contains(visibleCharacters[i]))
-                continue;
-
-            characterName = visibleCharacters[i];
-            index = i;
-            return true;
-        }
-
-        characterName = string.Empty;
+        reason = skipReasons.Count == 0
+            ? lobbyEntries.Count == 0
+                ? "lobby data was unavailable and no configured character was visible"
+                : "no visible whitelisted character matched the configured whitelist"
+            : string.Join("; ", skipReasons.Distinct());
         return false;
     }
 
@@ -198,22 +305,47 @@ public static class AutoLoginPlanner {
         }
 
         foreach (var entry in lobbyEntries) {
-            if (entry.Name.Equals(candidate.Name, StringComparison.InvariantCultureIgnoreCase))
+            if (entry.Name.Equals(candidate.Name, StringComparison.InvariantCultureIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(candidate.HomeWorldName) &&
+                entry.HomeWorldName.Equals(candidate.HomeWorldName, StringComparison.InvariantCultureIgnoreCase))
                 return entry;
         }
 
         return null;
     }
 
-    private static AutoLoginCandidate? FindCandidateByVisibleName(
-        IReadOnlyList<AutoLoginCandidate> candidates,
-        string visibleCharacterName) {
-        foreach (var candidate in candidates) {
-            if (candidate.Name.Equals(visibleCharacterName, StringComparison.InvariantCultureIgnoreCase))
-                return candidate;
+    private static List<AutoLoginLobbyEntry> FindSameNameEntries(
+        AutoLoginCandidate candidate,
+        IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries) =>
+        lobbyEntries
+            .Where(entry => entry.Name.Equals(candidate.Name, StringComparison.InvariantCultureIgnoreCase))
+            .ToList();
+
+    private static bool IsConfirmedCandidate(
+        AutoLoginCandidate candidate,
+        AutoLoginLobbyEntry entry,
+        out AutoLoginMatchConfidence confidence,
+        out string reason) {
+        confidence = AutoLoginMatchConfidence.None;
+        reason = string.Empty;
+
+        if (!entry.Name.Equals(candidate.Name, StringComparison.InvariantCultureIgnoreCase))
+            return false;
+
+        if (candidate.ContentId != 0 && entry.ContentId == candidate.ContentId) {
+            confidence = AutoLoginMatchConfidence.ContentId;
+            reason = $"resolved visible whitelisted character '{candidate.Name}' by content ID";
+            return true;
         }
 
-        return null;
+        if (!string.IsNullOrWhiteSpace(candidate.HomeWorldName) &&
+            entry.HomeWorldName.Equals(candidate.HomeWorldName, StringComparison.InvariantCultureIgnoreCase)) {
+            confidence = AutoLoginMatchConfidence.NameAndHomeWorld;
+            reason = $"resolved visible whitelisted character '{candidate.Name}' by name and home world '{candidate.HomeWorldName}'";
+            return true;
+        }
+
+        return false;
     }
 
     private static Dictionary<string, AutoLoginWorldEntry> BuildVisibleWorldMap(IReadOnlyList<AutoLoginWorldEntry> visibleWorlds) {
@@ -276,4 +408,12 @@ public static class AutoLoginPlanner {
         string.IsNullOrWhiteSpace(candidate.HomeWorldName)
             ? $"{candidate.Name}({candidate.ContentId})"
             : $"{candidate.Name}@{candidate.HomeWorldName}({candidate.ContentId})";
+
+    private static string FormatLobbyEntries(IReadOnlyList<AutoLoginLobbyEntry> entries) =>
+        entries.Count == 0
+            ? "<empty>"
+            : string.Join("; ", entries.Select(FormatLobbyEntry));
+
+    private static string FormatLobbyEntry(AutoLoginLobbyEntry entry) =>
+        $"{entry.Name}@{entry.HomeWorldName}/{entry.CurrentWorldName}({entry.ContentId})";
 }

--- a/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
@@ -256,8 +256,12 @@ internal partial class IpcProvider {
         if (anchor.Kind == FormationAnchorKind.Default)
             anchor = FormationAnchorReference.Self;
 
-        if (!FormationAnchorResolver.TryResolve(Plugin, formation, anchor, out var resolved, out var failureReason)) {
-            DalamudApi.ShowNotification(failureReason, NotificationType.Error, 5000);
+        if (!FormationAnchorResolver.TryResolve(Plugin, formation, anchor, out var resolved, out var failureReason, out var failureKind)) {
+            if (FormationLocalMovementExecutor.IsTransientAnchorFailure(failureKind)) {
+                DalamudApi.PluginLog.Debug($"[FormationAnchor] {failureReason}");
+            } else {
+                DalamudApi.ShowNotification(failureReason, NotificationType.Error, 5000);
+            }
             return false;
         }
 

--- a/MasterOfPuppets/Ipc/IpcProvider.Macro.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.Macro.cs
@@ -10,13 +10,27 @@ internal partial class IpcProvider {
 
     public void RunMacro(int macroIndex, Dictionary<string, string>? inlineVars = null, bool includeSelf = true) {
         DalamudApi.PluginLog.Debug($"[Run Macro] {macroIndex + 1}");
-        if (inlineVars is { Count: > 0 }) {
-            var varsToken = "-var=" + string.Join(";", inlineVars.Select(kv => $"${kv.Key}={kv.Value}"));
+        var originVars = AddMacroOriginVariables(inlineVars);
+        if (originVars.Count > 0) {
+            var varsToken = "-var=" + string.Join(";", originVars.Select(kv => $"${kv.Key}={FormatInlineVarValue(kv.Value)}"));
             BroadCast(IpcMessage.Create(IpcMessageType.RunMacro, macroIndex.ToString(), varsToken).Serialize(), includeSelf);
         } else {
             BroadCast(IpcMessage.Create(IpcMessageType.RunMacro, macroIndex.ToString()).Serialize(), includeSelf);
         }
     }
+
+    private static Dictionary<string, string> AddMacroOriginVariables(Dictionary<string, string>? inlineVars) {
+        var result = inlineVars == null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(inlineVars, StringComparer.OrdinalIgnoreCase);
+        var runtime = MacroRuntimeVariables.FromCurrentGameState();
+        result["mop_origin"] = runtime.MopOrigin;
+        result["mop_origin_target"] = runtime.MopOriginTarget;
+        return result;
+    }
+
+    private static string FormatInlineVarValue(string value) =>
+        string.IsNullOrEmpty(value) ? "\"\"" : value;
 
     [IpcHandle(IpcMessageType.RunMacro)]
     private void HandleRunMacro(IpcMessage message) {

--- a/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
+++ b/MasterOfPuppets/MopMacro/FormationMacroGenerator.cs
@@ -159,10 +159,8 @@ public static class FormationMacroGenerator {
         var step = Math.Max(1, options.Step);
         var movementMode = SimpleInputMovement.FormatMode(options.FormationMoveMode);
         var anchorArg = options.FormationMoveAnchorMode == FormationMoveAnchorMode.Target
-            ? " anchor=target"
-            : string.IsNullOrWhiteSpace(options.OriginReference)
-                ? " anchor=self"
-                : $" anchor=\"{ArgumentParser.EscapeQuotedArgument(options.OriginReference)}\"";
+            ? " anchor=\"$mop_origin_target\""
+            : " anchor=\"$mop_origin\"";
 
         foreach (var start in destinations) {
             var assignment = BuildAssignment(start.Point, groups, options.UseMatchingGroups);

--- a/MasterOfPuppets/MopMacro/MacroRuntimeVariables.cs
+++ b/MasterOfPuppets/MopMacro/MacroRuntimeVariables.cs
@@ -6,10 +6,14 @@ namespace MasterOfPuppets;
 public sealed class MacroRuntimeVariables {
     public string Me { get; init; } = string.Empty;
     public string Target { get; init; } = string.Empty;
+    public string MopOrigin { get; init; } = string.Empty;
+    public string MopOriginTarget { get; init; } = string.Empty;
 
     public Dictionary<string, string> ToDictionary() => new() {
         ["me"] = Me,
         ["target"] = Target,
+        ["mop_origin"] = MopOrigin,
+        ["mop_origin_target"] = MopOriginTarget,
     };
 
     public Dictionary<string, string> ResolveInlinePlaceholders(Dictionary<string, string>? inlineVars) {
@@ -49,6 +53,8 @@ public sealed class MacroRuntimeVariables {
         return new MacroRuntimeVariables {
             Me = me,
             Target = GameTargetManager.GetTargetName(),
+            MopOrigin = me,
+            MopOriginTarget = GameTargetManager.GetTargetName(),
         };
     }
 }

--- a/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
+++ b/MasterOfPuppets/MopMacro/MopCommandsHelper.cs
@@ -1243,7 +1243,7 @@ public static class MopCommandsHelper {
             Broadcasts one saved-formation movement step from the current character.
             Stride is the skip amount through formation point order; sequenceIndex is the zero-based step to execute from each recipient's computed path.
             Default: precise. Use continuous for smoother loops.
-            Add target to anchor the movement at your current target.
+            Add target to anchor the movement at the controller's current target.
             Generated formation macros use continuous by default.
             """
         },
@@ -1262,6 +1262,7 @@ public static class MopCommandsHelper {
             Moves only this client to a specific saved formation point.
             Point numbers are 1-based; point 1 is always the live anchor/origin.
             Use anchor="Name@World" when each PC should place itself relative to the same visible anchor character.
+            anchor=target uses this client's current target.
             Default: precise. Use continuous for smoother loops.
             This is the precise local alternative to IPC-broadcast /mopformationmove.
             """

--- a/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
+++ b/MasterOfPuppets/Ui/Windows/Macros/MacroEditorWindow.Generation.cs
@@ -46,7 +46,8 @@ public partial class MacroEditorWindow {
     private static readonly string[] MacroGeneratorDirectionNames = ["Forward through point order", "Backward through point order"];
     private static readonly string[] MacroGeneratorExistingFormationCommandStyleNames = ["Broadcast formation move", "Local point commands"];
     private static readonly string[] MacroGeneratorMovementModeNames = ["Continuous", "Precise"];
-    private static readonly string[] MacroGeneratorAnchorModeNames = ["Self", "Current target"];
+    private static readonly string[] MacroGeneratorBroadcastAnchorModeNames = ["Controller", "Controller target"];
+    private static readonly string[] MacroGeneratorLocalPointAnchorModeNames = ["Point 1", "Point 1 target"];
 
     private void DrawMacroCommandGeneratorModal() {
         ImGui.SetNextWindowSize(new Vector2(520f, 0f), ImGuiCond.FirstUseEver);
@@ -64,7 +65,7 @@ public partial class MacroEditorWindow {
         _macroGenFormationIndex = Math.Clamp(_macroGenFormationIndex, 0, formations.Count - 1);
         var selectedFormation = formations[_macroGenFormationIndex];
 
-        ImGui.TextWrapped("This inserts commands for characters assigned to the selected formation. Offsets are measured from the point assigned to your current character.");
+        ImGui.TextWrapped("This inserts commands for characters assigned to the selected formation. Point 1 is the formation origin.");
         ImGui.Separator();
 
         var localCid = DalamudApi.PlayerState.ContentId;
@@ -146,12 +147,12 @@ public partial class MacroEditorWindow {
 
     private void DrawMacroGeneratorMovementControls() {
         var originName = GetLocalPlayerNameWorld();
-        DrawMacroGeneratorLabel("Movement origin", "Generated movement is anchored from the current character. Target anchoring for existing formations is configured under Advanced.");
+        DrawMacroGeneratorLabel("Current character", "Local point macros must be started by point 1.");
         ImGui.TextDisabled(string.IsNullOrWhiteSpace(originName) ? "Could not resolve current character." : originName);
 
         if (_macroGenSource == 0) {
             ImGui.TextDisabled("Existing formations can use broadcast steps or local point commands.");
-            ImGuiUtil.HelpMarker("Broadcast uses /mopformationmove over IPC. Local point commands use /mopformationgoto on each assigned client with point 1 as the anchor.");
+            ImGuiUtil.HelpMarker("Broadcast uses controller steps. Local point commands run on each assigned client.");
         }
 
         DrawMacroGenFloat("Seconds per unit", "Wait seconds per unit of path distance.", ref _macroGenTravelSecondsPerUnit, 0.01f, 0.01f, 10f, "%.2f");
@@ -293,7 +294,7 @@ public partial class MacroEditorWindow {
         }
 
         if (existingFormationMovement) {
-            DrawMacroGeneratorLabel("Command style", "Broadcast sends one IPC formation step from this client. Local point commands run independently on each assigned client using point 1 as the anchor.");
+            DrawMacroGeneratorLabel("Command style", "Broadcast sends controller steps. Local point commands run on each assigned client.");
             ImGui.SetNextItemWidth(220);
             ImGui.Combo("##macroGenExistingFormationCommandStyle", ref _macroGenExistingFormationCommandStyle, MacroGeneratorExistingFormationCommandStyleNames, MacroGeneratorExistingFormationCommandStyleNames.Length);
 
@@ -301,9 +302,17 @@ public partial class MacroEditorWindow {
             ImGui.SetNextItemWidth(160);
             ImGui.Combo("##macroGenFormationMoveMode", ref _macroGenFormationMoveMode, MacroGeneratorMovementModeNames, MacroGeneratorMovementModeNames.Length);
 
-            DrawMacroGeneratorLabel("Movement anchor", "Use self position or current target position as the live anchor.");
+            var localPointCommands = _macroGenExistingFormationCommandStyle == 1;
+            var anchorNames = localPointCommands
+                ? MacroGeneratorLocalPointAnchorModeNames
+                : MacroGeneratorBroadcastAnchorModeNames;
+            DrawMacroGeneratorLabel(
+                "Origin",
+                localPointCommands
+                    ? "Where point 1 is placed. Run local point macros from point 1."
+                    : "Where the controller places the formation.");
             ImGui.SetNextItemWidth(160);
-            ImGui.Combo("##macroGenFormationMoveAnchor", ref _macroGenFormationMoveAnchorMode, MacroGeneratorAnchorModeNames, MacroGeneratorAnchorModeNames.Length);
+            ImGui.Combo("##macroGenFormationMoveAnchor", ref _macroGenFormationMoveAnchorMode, anchorNames, anchorNames.Length);
         }
 
         if (petEnabled) {
@@ -362,8 +371,8 @@ public partial class MacroEditorWindow {
         var useLocalFormationPointCommand = _macroGenSource == 0
             && movementEnabled
             && _macroGenExistingFormationCommandStyle == 1;
-        if (useLocalFormationPointCommand && _macroGenFormationMoveAnchorMode == 0 && originPointIndex != FormationPointMovement.AnchorPointIndex)
-            return new MacroCommandGeneratorPreview(false, "Local point commands use point 1 as the anchor. Assign your current character to point 1, or use Current target as the movement anchor.", []);
+        if (useLocalFormationPointCommand && originPointIndex != FormationPointMovement.AnchorPointIndex)
+            return new MacroCommandGeneratorPreview(false, "Local point commands must be started by point 1.", []);
         if (_macroGenSource == 1 && movementEnabled && string.IsNullOrWhiteSpace(GetLocalPlayerNameWorld()))
             return new MacroCommandGeneratorPreview(false, "Current character name/world must be resolved before generated shape movement commands can be created.", []);
         if (_macroGenSource == 1 && movementEnabled && GetLocalPlayerRotation() == null)

--- a/MasterOfPuppetsTests/ArgsParserTests.cs
+++ b/MasterOfPuppetsTests/ArgsParserTests.cs
@@ -117,6 +117,15 @@ public class ArgsParserTests
     }
 
     [Fact]
+    public void ParseInlineVars_QuotedEmptyValue_ReturnsEmptyString()
+    {
+        var result = ArgumentParser.ParseInlineVars("-var=$mop_origin_target=\"\"");
+
+        Assert.True(result.ContainsKey("mop_origin_target"));
+        Assert.Equal(string.Empty, result["mop_origin_target"]);
+    }
+
+    [Fact]
     public void ParseInlineVars_WrongPrefix_ReturnsEmpty()
     {
         var result = ArgumentParser.ParseInlineVars("--flags=$x=1;$y=2");

--- a/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
+++ b/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
@@ -62,13 +62,37 @@ public class AutoLoginPlannerTests {
     }
 
     [Fact]
-    public void BuildWorldQueue_MatchesByNameWhenContentIdIsMissing() {
+    public void BuildWorldQueue_DoesNotUseNameOnlyWhenContentIdIsMissing() {
         var queue = AutoLoginPlanner.BuildWorldQueue(
             [new AutoLoginCandidate(0, "Test Character")],
             [LobbyEntry(42, "Test Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos")],
             ["Diabolos", "Halicarnassus"]);
 
+        Assert.Equal(["Diabolos", "Halicarnassus"], queue);
+    }
+
+    [Fact]
+    public void BuildWorldQueue_UsesNameAndHomeWorldWhenContentIdIsMissing() {
+        var queue = AutoLoginPlanner.BuildWorldQueue(
+            [new AutoLoginCandidate(0, "Test Character", "Diabolos")],
+            [LobbyEntry(42, "Test Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos")],
+            ["Diabolos", "Halicarnassus"]);
+
         Assert.Equal(["Halicarnassus", "Diabolos"], queue);
+    }
+
+    [Fact]
+    public void BuildWorldQueue_DoesNotUseSameNameWrongHomeWorld() {
+        var result = AutoLoginPlanner.BuildWorldQueueWithDiagnostics(
+            [new AutoLoginCandidate(0, "Same Name", "Diabolos")],
+            [LobbyEntry(42, "Same Name", currentWorld: "Halicarnassus", homeWorld: "Golem")],
+            [
+                World("Diabolos", characterCount: null),
+                World("Halicarnassus", characterCount: null),
+            ]);
+
+        Assert.Equal(["Diabolos", "Halicarnassus"], result.Worlds);
+        Assert.Contains(result.Diagnostics, i => i.Contains("Ignored same-name lobby entries", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -204,16 +228,141 @@ public class AutoLoginPlannerTests {
     public void TryFindVisibleCandidate_MatchesByCandidateOrderInVisibleList() {
         var found = AutoLoginPlanner.TryFindVisibleCandidate(
             [
-                new AutoLoginCandidate(42, "Test Character"),
-                new AutoLoginCandidate(100, "Other Character"),
+                new AutoLoginCandidate(42, "Test Character", "Diabolos"),
+                new AutoLoginCandidate(100, "Other Character", "Diabolos"),
+            ],
+            [
+                LobbyEntry(42, "Test Character", currentWorld: "Diabolos", homeWorld: "Diabolos"),
+                LobbyEntry(100, "Other Character", currentWorld: "Diabolos", homeWorld: "Diabolos"),
             ],
             ["Not It", "Other Character", "Test Character"],
+            "Diabolos",
             out var characterName,
-            out var index);
+            out var index,
+            out var reason);
 
-        Assert.True(found);
+        Assert.True(found, reason);
         Assert.Equal("Other Character", characterName);
         Assert.Equal(1, index);
+    }
+
+    [Fact]
+    public void TryFindVisibleCandidate_RejectsSameNameWrongHomeWorld() {
+        var found = AutoLoginPlanner.TryFindVisibleCandidate(
+            [new AutoLoginCandidate(42, "Same Name", "Diabolos")],
+            [LobbyEntry(100, "Same Name", currentWorld: "Diabolos", homeWorld: "Golem")],
+            ["Same Name"],
+            "Diabolos",
+            out var characterName,
+            out var index,
+            out var reason);
+
+        Assert.False(found);
+        Assert.Equal(string.Empty, characterName);
+        Assert.Equal(-1, index);
+        Assert.Contains("did not match configured identity", reason);
+    }
+
+    [Fact]
+    public void TryFindVisibleCandidateMatch_ReturnsContentIdConfidence() {
+        var found = AutoLoginPlanner.TryFindVisibleCandidateMatch(
+            [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
+            [LobbyEntry(42, "Test Character", currentWorld: "Diabolos", homeWorld: "Diabolos")],
+            ["Test Character"],
+            "Diabolos",
+            out var match,
+            out var reason);
+
+        Assert.True(found, reason);
+        Assert.Equal(AutoLoginMatchConfidence.ContentId, match.Confidence);
+        Assert.Equal("Test Character", match.Target.CharacterName);
+        Assert.Equal("Diabolos", match.Target.WorldName);
+        Assert.Equal(0, match.Index);
+    }
+
+    [Fact]
+    public void TryFindVisibleCandidateMatch_ReturnsNameAndHomeWorldConfidence() {
+        var found = AutoLoginPlanner.TryFindVisibleCandidateMatch(
+            [new AutoLoginCandidate(0, "Test Character", "Diabolos")],
+            [LobbyEntry(42, "Test Character", currentWorld: "Halicarnassus", homeWorld: "Diabolos")],
+            ["Test Character"],
+            "Halicarnassus",
+            out var match,
+            out var reason);
+
+        Assert.True(found, reason);
+        Assert.Equal(AutoLoginMatchConfidence.NameAndHomeWorld, match.Confidence);
+        Assert.Equal("Test Character", match.Target.CharacterName);
+        Assert.Equal("Halicarnassus", match.Target.WorldName);
+        Assert.Equal(0, match.Index);
+    }
+
+    [Fact]
+    public void TryFindVisibleCandidateMatch_ReturnsConfiguredHomeWorldFallbackConfidence() {
+        var found = AutoLoginPlanner.TryFindVisibleCandidateMatch(
+            [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
+            [],
+            ["Test Character"],
+            "Diabolos",
+            out var match,
+            out var reason);
+
+        Assert.True(found, reason);
+        Assert.Equal(AutoLoginMatchConfidence.NameOnConfiguredHomeWorld, match.Confidence);
+        Assert.Equal("Test Character", match.Target.CharacterName);
+        Assert.Equal("Diabolos", match.Target.WorldName);
+        Assert.Equal(0, match.Index);
+    }
+
+    [Fact]
+    public void TryFindVisibleCandidate_AcceptsNameOnConfiguredHomeWorldWhenLobbyUnavailable() {
+        var found = AutoLoginPlanner.TryFindVisibleCandidate(
+            [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
+            [],
+            ["Test Character"],
+            "Diabolos",
+            out var characterName,
+            out var index,
+            out var reason);
+
+        Assert.True(found, reason);
+        Assert.Equal("Test Character", characterName);
+        Assert.Equal(0, index);
+        Assert.Contains("configured home world", reason);
+    }
+
+    [Fact]
+    public void TryFindVisibleCandidate_RejectsNameOnlyOnWrongWorldWhenLobbyUnavailable() {
+        var found = AutoLoginPlanner.TryFindVisibleCandidate(
+            [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
+            [],
+            ["Test Character"],
+            "Golem",
+            out var characterName,
+            out var index,
+            out var reason);
+
+        Assert.False(found);
+        Assert.Equal(string.Empty, characterName);
+        Assert.Equal(-1, index);
+        Assert.Contains("is not configured home world", reason);
+    }
+
+    [Fact]
+    public void TryFindVisibleCandidate_AcceptsTraveledCharacterWhenLobbyHomeWorldMatches() {
+        var found = AutoLoginPlanner.TryFindVisibleCandidate(
+            [new AutoLoginCandidate(42, "Test Character", "Golem")],
+            [LobbyEntry(42, "Test Character", currentWorld: "Diabolos", homeWorld: "Golem")],
+            ["Test Character"],
+            "Diabolos",
+            out var characterName,
+            out var index,
+            out var reason);
+
+        Assert.True(found, reason);
+        Assert.Equal("Test Character", characterName);
+        Assert.Equal(0, index);
+        Assert.Contains("content ID", reason);
     }
 
     [Fact]
@@ -236,6 +385,22 @@ public class AutoLoginPlannerTests {
         Assert.Equal("Other Character", target.CharacterName);
         Assert.Equal("Diabolos", target.WorldName);
         Assert.Equal(0, index);
+    }
+
+    [Fact]
+    public void TryResolveDirectCharacterListMatch_ReturnsMatchConfidence() {
+        var found = AutoLoginPlanner.TryResolveDirectCharacterListMatch(
+            [new AutoLoginCandidate(0, "Other Character", "Diabolos")],
+            [LobbyEntry(100, "Other Character", currentWorld: "Diabolos", homeWorld: "Diabolos")],
+            ["Other Character"],
+            out var match,
+            out var reason);
+
+        Assert.True(found, reason);
+        Assert.Equal(AutoLoginMatchConfidence.NameAndHomeWorld, match.Confidence);
+        Assert.Equal("Other Character", match.Target.CharacterName);
+        Assert.Equal("Diabolos", match.Target.WorldName);
+        Assert.Equal(0, match.Index);
     }
 
     [Fact]
@@ -277,7 +442,7 @@ public class AutoLoginPlannerTests {
     }
 
     [Fact]
-    public void TryResolveDirectCharacterListTarget_SelectsVisibleWhitelistedCharacterMissingFromLobby() {
+    public void TryResolveDirectCharacterListTarget_RejectsVisibleWhitelistedCharacterMissingFromLobby() {
         var found = AutoLoginPlanner.TryResolveDirectCharacterListTarget(
             [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
             [LobbyEntry(999, "Not Configured", currentWorld: "Diabolos", homeWorld: "Diabolos")],
@@ -286,15 +451,14 @@ public class AutoLoginPlannerTests {
             out var index,
             out var reason);
 
-        Assert.True(found, reason);
-        Assert.Equal("Test Character", target.CharacterName);
-        Assert.Equal(string.Empty, target.WorldName);
-        Assert.Equal(0, index);
-        Assert.Contains("without lobby confirmation", reason);
+        Assert.False(found);
+        Assert.Equal(default, target);
+        Assert.Equal(-1, index);
+        Assert.Contains("no lobby confirmation", reason);
     }
 
     [Fact]
-    public void TryResolveDirectCharacterListTarget_FallsBackToVisibleCandidateWhenLobbyUnavailable() {
+    public void TryResolveDirectCharacterListTarget_RejectsVisibleCandidateWhenLobbyUnavailable() {
         var found = AutoLoginPlanner.TryResolveDirectCharacterListTarget(
             [
                 new AutoLoginCandidate(42, "Test Character"),
@@ -306,11 +470,10 @@ public class AutoLoginPlannerTests {
             out var index,
             out var reason);
 
-        Assert.True(found, reason);
-        Assert.Equal("Other Character", target.CharacterName);
-        Assert.Equal(string.Empty, target.WorldName);
-        Assert.Equal(0, index);
-        Assert.Contains("lobby data was unavailable", reason);
+        Assert.False(found);
+        Assert.Equal(default, target);
+        Assert.Equal(-1, index);
+        Assert.Contains("configured home world is unknown", reason);
     }
 
     private static AutoLoginLobbyEntry LobbyEntry(

--- a/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
+++ b/MasterOfPuppetsTests/FormationMacroGeneratorTests.cs
@@ -423,9 +423,9 @@ public class FormationMacroGeneratorTests {
         Assert.Empty(result.Macro.Commands[0].GroupIds);
 
         var lines = result.Macro.Commands[0].Actions.Split('\n');
-        Assert.Equal("/mopformationgoto \"Circle\" 2 anchor=\"Origin Character@World\" continuous", lines[0]);
+        Assert.Equal("/mopformationgoto \"Circle\" 2 anchor=\"$mop_origin\" continuous", lines[0]);
         Assert.Equal("/mopwait 1.00", lines[1]);
-        Assert.Equal("/mopformationgoto \"Circle\" 3 anchor=\"Origin Character@World\" continuous", lines[2]);
+        Assert.Equal("/mopformationgoto \"Circle\" 3 anchor=\"$mop_origin\" continuous", lines[2]);
         Assert.DoesNotContain("/mopformationmove", result.Macro.Commands[0].Actions);
         Assert.EndsWith("/moploop", result.Macro.Commands[0].Actions);
     }
@@ -450,7 +450,7 @@ public class FormationMacroGeneratorTests {
     }
 
     [Fact]
-    public void GenerateLoopMacro_ExistingFormationLocalPointMovement_EmitsTargetAndPreciseOptions() {
+    public void GenerateLoopMacro_ExistingFormationLocalPointMovement_EmitsPointOneTargetAndPreciseOptions() {
         var formation = BuildEightPointFormation();
 
         var result = FormationMacroGenerator.GenerateLoopMacroWithDiagnostics(
@@ -465,7 +465,8 @@ public class FormationMacroGeneratorTests {
 
         var command = Assert.Single(result.Macro.Commands, command => command.Cids.SequenceEqual([101UL]));
         var firstLine = command.Actions.Split('\n')[0];
-        Assert.Equal("/mopformationgoto \"Circle\" 2 anchor=target precise", firstLine);
+        Assert.Equal("/mopformationgoto \"Circle\" 2 anchor=\"$mop_origin_target\" precise", firstLine);
+        Assert.DoesNotContain("anchor=target", command.Actions);
     }
 
     [Fact]

--- a/MasterOfPuppetsTests/MacroTests.cs
+++ b/MasterOfPuppetsTests/MacroTests.cs
@@ -167,6 +167,19 @@ public class MacroTests
         Assert.False(MacroHandler.CommandSkipsGlobalDelay("mopformationmove"));
     }
 
+    [Theory]
+    [InlineData(FormationAnchorFailureKind.NoTargetSelected, true)]
+    [InlineData(FormationAnchorFailureKind.AnchorNameEmpty, true)]
+    [InlineData(FormationAnchorFailureKind.AnchorNotVisible, true)]
+    [InlineData(FormationAnchorFailureKind.ConfigurationError, false)]
+    [InlineData(FormationAnchorFailureKind.Unsupported, false)]
+    public void FormationAnchorFailures_Classify_Transient_Runtime_Misses(
+        FormationAnchorFailureKind failureKind,
+        bool expectedTransient)
+    {
+        Assert.Equal(expectedTransient, FormationLocalMovementExecutor.IsTransientAnchorFailure(failureKind));
+    }
+
     [Fact]
     public void ParseFormationMoveCommandArgs_Defaults_To_Precise()
     {

--- a/MasterOfPuppetsTests/MacroTests.cs
+++ b/MasterOfPuppetsTests/MacroTests.cs
@@ -63,7 +63,7 @@ public class MacroTests
             Commands = new List<Command> {
                 new Command {
                     Cids = new() { 1 },
-                    Actions = "/moptarget \"$target\"\n/echo $me"
+                    Actions = "/moptarget \"$target\"\n/echo $me\n/echo $mop_origin\n/echo $mop_origin_target"
                 }
             }
         };
@@ -74,10 +74,17 @@ public class MacroTests
             {
                 Me = "Current Character@World",
                 Target = "Target Character@World",
+                MopOrigin = "Origin Character@World",
+                MopOriginTarget = "Origin Target@World",
             });
 
         Assert.Equal(
-            new[] { "/moptarget \"Target Character@World\"", "/echo Current Character@World" },
+            new[] {
+                "/moptarget \"Target Character@World\"",
+                "/echo Current Character@World",
+                "/echo Origin Character@World",
+                "/echo Origin Target@World",
+            },
             result);
     }
 


### PR DESCRIPTION
- Add better /mopformationgoto anchoring options - can't use "current target" if the command runs locally per client
- [Stop spamming errors when we lose target for a target formation macro](https://github.com/zunetrix/MasterOfPuppets/commit/7de0668da186f05f97c5338c48c9106f0015f3f1)
- [Don't login just by matching name - first try CID, then Name@HomeWorld](https://github.com/zunetrix/MasterOfPuppets/pull/10/commits/1c97805f9a8d3156b365780964c677a9dfab31eb)