### PR TITLE
Handle "could not be found" dialog during autologin process

### DIFF
--- a/MasterOfPuppets/Game/GameDialog/GameDialogManager.cs
+++ b/MasterOfPuppets/Game/GameDialog/GameDialogManager.cs
@@ -108,6 +108,20 @@ internal static unsafe partial class GameDialogManager {
     public static bool ClickNo() => FireCallback(AddonName.SelectYesno, 1);
     // public static bool ClickNo() => ClickAddonButton<AddonSelectYesno>(AddonName.SelectYesno, a => a->NoButton);
     public static bool ClickOk() => ClickAddonButton<AddonSelectOk>(AddonName.SelectOk, a => a->OkButton);
+    public static bool TryGetSelectOkText(out string text) {
+        text = string.Empty;
+        var addon = (AddonSelectOk*)GetAddonByName(AddonName.SelectOk);
+        if (addon == null || addon->PromptText == null)
+            return false;
+
+        var rawText = addon->PromptText->NodeText.ToString();
+        text = new ReadOnlySeStringSpan(addon->PromptText->NodeText.AsSpan()).ExtractText();
+        if (string.IsNullOrWhiteSpace(text))
+            text = rawText;
+
+        return !string.IsNullOrWhiteSpace(text);
+    }
+
     public static bool ClickRepairAll() => ClickAddonButton<AddonRepair>(AddonName.Repair, a => a->RepairAllButton);
     public static bool ClickContentsFinderConfirm() => ClickAddonButton<AddonContentsFinderConfirm>(AddonName.ContentsFinderConfirm, a => a->CommenceButton);
     // ContentsFinderConfirm // addon->ReceiveEvent(AtkEventType.ButtonClick, 8, &eventData, &inputData);

--- a/MasterOfPuppets/Game/Login/AutoLoginDialogMatcher.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginDialogMatcher.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace MasterOfPuppets;
+
+public static class AutoLoginDialogMatcher {
+    public static bool IsMissingLastLoggedOutCharacterSelectOk(string text) {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var normalized = Normalize(text);
+        return normalized.Contains("last logged out", StringComparison.OrdinalIgnoreCase) &&
+               normalized.Contains("could not be found", StringComparison.OrdinalIgnoreCase) &&
+               normalized.Contains("current data center", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Normalize(string text) =>
+        string.Join(' ', text.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries));
+}

--- a/MasterOfPuppets/Game/Login/AutoLoginManager.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginManager.cs
@@ -44,6 +44,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
     private bool _loggedCharacterListSnapshot;
     private bool _loggedDirectCharacterListMismatch;
     private bool _loginConfirmationSubmitted;
+    private bool _preLoginSelectOkSubmitted;
     private bool _loggedWaitingLoginConfirmation;
     private bool _loggedWaitingWorldListAfterTitleAction;
     private bool _waitingForWorldSelectionSettle;
@@ -85,6 +86,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         _loggedCharacterListSnapshot = false;
         _loggedDirectCharacterListMismatch = false;
         _loginConfirmationSubmitted = false;
+        _preLoginSelectOkSubmitted = false;
         _loggedWaitingLoginConfirmation = false;
         _loggedWaitingWorldListAfterTitleAction = false;
         _waitingForWorldSelectionSettle = false;
@@ -115,6 +117,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
         _loggedCharacterListSnapshot = false;
         _loggedDirectCharacterListMismatch = false;
         _loginConfirmationSubmitted = false;
+        _preLoginSelectOkSubmitted = false;
         _loggedWaitingLoginConfirmation = false;
         _loggedWaitingWorldListAfterTitleAction = false;
         _waitingForWorldSelectionSettle = false;
@@ -149,6 +152,9 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
                 return;
             }
 
+            if (!_loginConfirmationSubmitted && TryClearPreLoginSelectOk())
+                return;
+
             switch (_state) {
                 case LoginState.WaitingTitleMenu:
                     HandleWaitingTitleMenu();
@@ -167,6 +173,27 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             DalamudApi.PluginLog.Warning(ex, "[AutoLogin] Failed.");
             Stop();
         }
+    }
+
+    private bool TryClearPreLoginSelectOk() {
+        if (_preLoginSelectOkSubmitted)
+            return false;
+
+        if (!GameDialogManager.TryGetSelectOkText(out var text))
+            return false;
+
+        if (!AutoLoginDialogMatcher.IsMissingLastLoggedOutCharacterSelectOk(text))
+            return false;
+
+        if (!GameDialogManager.ClickOk())
+            return true;
+
+        _preLoginSelectOkSubmitted = true;
+        _loggedWaitingLoginConfirmation = false;
+        _stateTimer.Restart();
+        DalamudApi.PluginLog.Debug(
+            $"[AutoLogin] Cleared pre-login SelectOk before login confirmation: \"{LogValue(text)}\".");
+        return true;
     }
 
     private void HandleWaitingTitleMenu() {
@@ -400,6 +427,7 @@ internal sealed unsafe class AutoLoginManager : IDisposable {
             $"{FormatAddonState("_CharaSelectWorldServer")}; " +
             $"{FormatAddonState("_CharaSelectListMenu")}; " +
             $"{FormatAddonState(GameDialogManager.AddonName.SelectYesno)}; " +
+            $"{FormatAddonState(GameDialogManager.AddonName.SelectOk)}; " +
             $"worldSelectorSource={(worldSelectorSnapshot.UsedAddonWorldEntries ? "WorldEntries" : "StringArrayFallback")}; " +
             $"selectedWorldIndex={worldSelectorSnapshot.SelectedWorldIndex}; " +
             $"worlds={worldSelectorWorlds.Count} [{FormatWorldSelectorSnapshot(worldSelectorWorlds)}]; " +

--- a/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginPlanner.cs
@@ -51,7 +51,6 @@ public enum AutoLoginMatchConfidence {
     None,
     ContentId,
     NameAndHomeWorld,
-    NameOnConfiguredHomeWorld,
 }
 
 public readonly record struct AutoLoginCharacterMatch(
@@ -172,7 +171,6 @@ public static class AutoLoginPlanner {
                 lobbyEntries,
                 visibleCharacters,
                 selectedWorldName: string.Empty,
-                allowConfiguredHomeWorldFallback: false,
                 out match,
                 out reason)) {
             return true;
@@ -219,7 +217,6 @@ public static class AutoLoginPlanner {
                 lobbyEntries,
                 visibleCharacters,
                 selectedWorldName,
-                allowConfiguredHomeWorldFallback: true,
                 out match,
                 out reason)) {
             return true;
@@ -234,7 +231,6 @@ public static class AutoLoginPlanner {
         IReadOnlyList<AutoLoginLobbyEntry> lobbyEntries,
         IReadOnlyList<string> visibleCharacters,
         string selectedWorldName,
-        bool allowConfiguredHomeWorldFallback,
         out AutoLoginCharacterMatch match,
         out string reason) {
         match = default;
@@ -271,19 +267,10 @@ public static class AutoLoginPlanner {
                     continue;
                 }
 
-                if (allowConfiguredHomeWorldFallback &&
-                    !string.IsNullOrWhiteSpace(candidate.HomeWorldName) &&
-                    candidate.HomeWorldName.Equals(selectedWorldName, StringComparison.InvariantCultureIgnoreCase)) {
-                    var target = new AutoLoginTarget(candidate.Name, selectedWorldName);
-                    reason = $"resolved visible whitelisted character '{candidate.Name}' on configured home world '{selectedWorldName}' without lobby confirmation";
-                    match = new AutoLoginCharacterMatch(candidate, target, i, AutoLoginMatchConfidence.NameOnConfiguredHomeWorld, reason);
-                    return true;
-                }
-
                 skipReasons.Add(
                     string.IsNullOrWhiteSpace(candidate.HomeWorldName)
                         ? $"skipped visible '{visibleName}': no lobby confirmation and configured home world is unknown for {FormatCandidate(candidate)}"
-                        : $"skipped visible '{visibleName}': no lobby confirmation and selected world '{selectedWorldName}' is not configured home world '{candidate.HomeWorldName}'");
+                        : $"skipped visible '{visibleName}': no lobby confirmation for configured identity {FormatCandidate(candidate)} on selected world '{selectedWorldName}'");
             }
         }
 

--- a/MasterOfPuppetsTests/AutoLoginDialogMatcherTests.cs
+++ b/MasterOfPuppetsTests/AutoLoginDialogMatcherTests.cs
@@ -1,0 +1,27 @@
+using MasterOfPuppets;
+
+using Xunit;
+
+namespace MasterOfPuppetsTests;
+
+public class AutoLoginDialogMatcherTests {
+    [Fact]
+    public void IsMissingLastLoggedOutCharacterSelectOk_MatchesKnownPreLoginDialog() {
+        var text = """
+                   The character you last logged out with in this play environment could not be found on the
+                   current data center.Please connect to another data center from the Data Center Selection screen.
+                   """;
+
+        Assert.True(AutoLoginDialogMatcher.IsMissingLastLoggedOutCharacterSelectOk(text));
+    }
+
+    [Fact]
+    public void IsMissingLastLoggedOutCharacterSelectOk_DoesNotMatchQueueDialog() {
+        var text = """
+                   The server is currently congested.
+                   Players in queue: 15.
+                   """;
+
+        Assert.False(AutoLoginDialogMatcher.IsMissingLastLoggedOutCharacterSelectOk(text));
+    }
+}

--- a/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
+++ b/MasterOfPuppetsTests/AutoLoginPlannerTests.cs
@@ -298,7 +298,7 @@ public class AutoLoginPlannerTests {
     }
 
     [Fact]
-    public void TryFindVisibleCandidateMatch_ReturnsConfiguredHomeWorldFallbackConfidence() {
+    public void TryFindVisibleCandidateMatch_RejectsConfiguredHomeWorldWithoutLobbyConfirmation() {
         var found = AutoLoginPlanner.TryFindVisibleCandidateMatch(
             [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
             [],
@@ -307,15 +307,13 @@ public class AutoLoginPlannerTests {
             out var match,
             out var reason);
 
-        Assert.True(found, reason);
-        Assert.Equal(AutoLoginMatchConfidence.NameOnConfiguredHomeWorld, match.Confidence);
-        Assert.Equal("Test Character", match.Target.CharacterName);
-        Assert.Equal("Diabolos", match.Target.WorldName);
-        Assert.Equal(0, match.Index);
+        Assert.False(found);
+        Assert.Equal(default, match);
+        Assert.Contains("no lobby confirmation", reason);
     }
 
     [Fact]
-    public void TryFindVisibleCandidate_AcceptsNameOnConfiguredHomeWorldWhenLobbyUnavailable() {
+    public void TryFindVisibleCandidate_RejectsNameOnConfiguredHomeWorldWhenLobbyUnavailable() {
         var found = AutoLoginPlanner.TryFindVisibleCandidate(
             [new AutoLoginCandidate(42, "Test Character", "Diabolos")],
             [],
@@ -325,10 +323,10 @@ public class AutoLoginPlannerTests {
             out var index,
             out var reason);
 
-        Assert.True(found, reason);
-        Assert.Equal("Test Character", characterName);
-        Assert.Equal(0, index);
-        Assert.Contains("configured home world", reason);
+        Assert.False(found);
+        Assert.Equal(string.Empty, characterName);
+        Assert.Equal(-1, index);
+        Assert.Contains("no lobby confirmation", reason);
     }
 
     [Fact]
@@ -345,7 +343,7 @@ public class AutoLoginPlannerTests {
         Assert.False(found);
         Assert.Equal(string.Empty, characterName);
         Assert.Equal(-1, index);
-        Assert.Contains("is not configured home world", reason);
+        Assert.Contains("no lobby confirmation", reason);
     }
 
     [Fact]


### PR DESCRIPTION
Add IsMissingLastLoggedOutCharacterSelectOk matcher for this specific dialog, and stop considering a character that's sitting on a server as that server being that character's homeworld.