### PR TITLE
Use sender as chat-sync anchor with cross-world PlayerPayload name resolution

### DIFF
--- a/MasterOfPuppets/Formations/FormationAnchorReference.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorReference.cs
@@ -8,6 +8,7 @@ namespace MasterOfPuppets.Formations;
 public enum FormationAnchorKind {
     Default,
     Self,
+    Sender,
     Target,
     FocusTarget,
     Named,
@@ -26,6 +27,7 @@ public enum FormationAnchorFailureKind {
 public sealed record FormationAnchorReference(FormationAnchorKind Kind, string? Name = null) {
     public static readonly FormationAnchorReference Default = new(FormationAnchorKind.Default);
     public static readonly FormationAnchorReference Self = new(FormationAnchorKind.Self);
+    public static readonly FormationAnchorReference Sender = new(FormationAnchorKind.Sender);
     public static readonly FormationAnchorReference Target = new(FormationAnchorKind.Target);
     public static readonly FormationAnchorReference FocusTarget = new(FormationAnchorKind.FocusTarget);
 
@@ -76,6 +78,8 @@ public static class FormationAnchorArgumentParser {
                 anchor = FormationAnchorReference.Default;
             } else if (candidate.Equals("self", StringComparison.OrdinalIgnoreCase)) {
                 anchor = FormationAnchorReference.Self;
+            } else if (candidate.Equals("sender", StringComparison.OrdinalIgnoreCase)) {
+                anchor = FormationAnchorReference.Sender;
             } else if (candidate.Equals("target", StringComparison.OrdinalIgnoreCase)) {
                 anchor = FormationAnchorReference.Target;
             } else if (candidate.Equals("ftarget", StringComparison.OrdinalIgnoreCase)
@@ -93,6 +97,7 @@ public static class FormationAnchorArgumentParser {
         anchor.Kind switch {
             FormationAnchorKind.Default => string.Empty,
             FormationAnchorKind.Self => "self",
+            FormationAnchorKind.Sender => "sender",
             FormationAnchorKind.Target => "target",
             FormationAnchorKind.FocusTarget => "ftarget",
             FormationAnchorKind.Named => $"\"{Util.ArgumentParser.EscapeQuotedArgument(anchor.Name ?? string.Empty)}\"",

--- a/MasterOfPuppets/Formations/FormationAnchorResolver.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorResolver.cs
@@ -39,6 +39,18 @@ public static class FormationAnchorResolver {
                     DalamudApi.PlayerState.ContentId,
                     GetLocalPlayerNameWorld());
                 return true;
+            case FormationAnchorKind.Sender:
+                if (string.IsNullOrWhiteSpace(anchor.Name)) {
+                    failureReason = "sender name is empty";
+                    failureKind = FormationAnchorFailureKind.AnchorNameEmpty;
+                    return false;
+                }
+
+                if (!TryResolveNamed(anchor.Name, out resolved, out failureReason, out failureKind))
+                    return false;
+
+                resolved = resolved with { ContentId = ResolveContentIdFromName(plugin, resolved.Name) };
+                return true;
             case FormationAnchorKind.Target:
                 if (player.TargetObject == null) {
                     failureReason = "no target selected";
@@ -67,7 +79,11 @@ public static class FormationAnchorResolver {
                     focusTarget.Name.TextValue);
                 return true;
             case FormationAnchorKind.Named:
-                return TryResolveNamed(anchor.Name ?? string.Empty, out resolved, out failureReason, out failureKind);
+                if (!TryResolveNamed(anchor.Name ?? string.Empty, out resolved, out failureReason, out failureKind))
+                    return false;
+
+                resolved = resolved with { ContentId = ResolveContentIdFromName(plugin, resolved.Name) };
+                return true;
             default:
                 failureReason = $"unsupported anchor kind {anchor.Kind}";
                 failureKind = FormationAnchorFailureKind.Unsupported;
@@ -171,6 +187,54 @@ public static class FormationAnchorResolver {
 
         var world = DalamudApi.PlayerState.HomeWorld.Value.Name.ToString();
         return string.IsNullOrWhiteSpace(world) ? name : $"{name}@{world}";
+    }
+
+    private static ulong? ResolveContentIdFromName(Plugin plugin, string actorFullName) {
+        if (string.IsNullOrWhiteSpace(actorFullName))
+            return null;
+
+        ulong? bestMatch = null;
+        var bestScore = -1;
+
+        foreach (var character in plugin.Config.Characters) {
+            if (string.IsNullOrWhiteSpace(character.Name))
+                continue;
+
+            var score = CharacterNameMatchScore(character.Name, actorFullName);
+            if (score > bestScore) {
+                bestScore = score;
+                bestMatch = character.Cid;
+            }
+        }
+
+        return bestScore >= 0 ? bestMatch : null;
+    }
+
+    private static int CharacterNameMatchScore(string configName, string actorName) {
+        if (string.Equals(configName, actorName, StringComparison.OrdinalIgnoreCase))
+            return int.MaxValue;
+
+        var configBaseName = GetBaseCharacterName(configName);
+        var actorBaseName = GetBaseCharacterName(actorName);
+
+        if (string.Equals(configBaseName, actorBaseName, StringComparison.OrdinalIgnoreCase))
+            return int.MaxValue - 1;
+
+        if (actorBaseName.Contains(configBaseName, StringComparison.OrdinalIgnoreCase))
+            return configBaseName.Length;
+
+        if (configBaseName.Contains(actorBaseName, StringComparison.OrdinalIgnoreCase))
+            return actorBaseName.Length;
+
+        return -1;
+    }
+
+    private static string GetBaseCharacterName(string fullName) {
+        if (string.IsNullOrWhiteSpace(fullName))
+            return string.Empty;
+
+        var atIndex = fullName.LastIndexOf('@');
+        return atIndex >= 0 ? fullName[..atIndex].Trim() : fullName.Trim();
     }
 
     private sealed record AnchorCandidate(IGameObject Actor, string Name, string FullName);

--- a/MasterOfPuppets/Formations/FormationAnchorResolver.cs
+++ b/MasterOfPuppets/Formations/FormationAnchorResolver.cs
@@ -100,6 +100,7 @@ public static class FormationAnchorResolver {
         failureReason = string.Empty;
         failureKind = FormationAnchorFailureKind.None;
 
+        objectName = FormationCharacterName.NormalizeWorldSeparator(objectName);
         if (string.IsNullOrWhiteSpace(objectName)) {
             failureReason = "anchor name is empty";
             failureKind = FormationAnchorFailureKind.AnchorNameEmpty;
@@ -116,7 +117,10 @@ public static class FormationAnchorResolver {
                     player.HomeWorld.ValueNullable is { } world)
                     fullName = $"{name}@{world.Name}";
 
-                return new AnchorCandidate(actor, name, fullName);
+                return new AnchorCandidate(
+                    actor,
+                    FormationCharacterName.NormalizeWorldSeparator(name),
+                    FormationCharacterName.NormalizeWorldSeparator(fullName));
             })
             .ToList();
 
@@ -181,15 +185,16 @@ public static class FormationAnchorResolver {
     }
 
     private static string GetLocalPlayerNameWorld() {
-        var name = DalamudApi.PlayerState.CharacterName;
+        var name = FormationCharacterName.NormalizeWorldSeparator(DalamudApi.PlayerState.CharacterName);
         if (string.IsNullOrWhiteSpace(name))
             return string.Empty;
 
-        var world = DalamudApi.PlayerState.HomeWorld.Value.Name.ToString();
+        var world = FormationCharacterName.NormalizeWorldSeparator(DalamudApi.PlayerState.HomeWorld.Value.Name.ToString());
         return string.IsNullOrWhiteSpace(world) ? name : $"{name}@{world}";
     }
 
     private static ulong? ResolveContentIdFromName(Plugin plugin, string actorFullName) {
+        actorFullName = FormationCharacterName.NormalizeWorldSeparator(actorFullName);
         if (string.IsNullOrWhiteSpace(actorFullName))
             return null;
 
@@ -200,7 +205,7 @@ public static class FormationAnchorResolver {
             if (string.IsNullOrWhiteSpace(character.Name))
                 continue;
 
-            var score = CharacterNameMatchScore(character.Name, actorFullName);
+            var score = FormationCharacterName.MatchScore(character.Name, actorFullName);
             if (score > bestScore) {
                 bestScore = score;
                 bestMatch = character.Cid;
@@ -208,33 +213,6 @@ public static class FormationAnchorResolver {
         }
 
         return bestScore >= 0 ? bestMatch : null;
-    }
-
-    private static int CharacterNameMatchScore(string configName, string actorName) {
-        if (string.Equals(configName, actorName, StringComparison.OrdinalIgnoreCase))
-            return int.MaxValue;
-
-        var configBaseName = GetBaseCharacterName(configName);
-        var actorBaseName = GetBaseCharacterName(actorName);
-
-        if (string.Equals(configBaseName, actorBaseName, StringComparison.OrdinalIgnoreCase))
-            return int.MaxValue - 1;
-
-        if (actorBaseName.Contains(configBaseName, StringComparison.OrdinalIgnoreCase))
-            return configBaseName.Length;
-
-        if (configBaseName.Contains(actorBaseName, StringComparison.OrdinalIgnoreCase))
-            return actorBaseName.Length;
-
-        return -1;
-    }
-
-    private static string GetBaseCharacterName(string fullName) {
-        if (string.IsNullOrWhiteSpace(fullName))
-            return string.Empty;
-
-        var atIndex = fullName.LastIndexOf('@');
-        return atIndex >= 0 ? fullName[..atIndex].Trim() : fullName.Trim();
     }
 
     private sealed record AnchorCandidate(IGameObject Actor, string Name, string FullName);

--- a/MasterOfPuppets/Formations/FormationCharacterName.cs
+++ b/MasterOfPuppets/Formations/FormationCharacterName.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace MasterOfPuppets.Formations;
+
+public static class FormationCharacterName {
+    private const char CrossWorldPrefix = '\uE0B1';
+    private const char CrossWorldSeparator = '\uE0B2';
+
+    public static string NormalizeWorldSeparator(string name) {
+        if (string.IsNullOrWhiteSpace(name))
+            return string.Empty;
+
+        var normalized = name.Trim()
+            .Replace(CrossWorldPrefix, '@')
+            .Replace(CrossWorldSeparator, '@')
+            .Replace(" @", "@", StringComparison.Ordinal)
+            .Replace("@ ", "@", StringComparison.Ordinal);
+
+        while (normalized.Contains("@@", StringComparison.Ordinal))
+            normalized = normalized.Replace("@@", "@", StringComparison.Ordinal);
+
+        return normalized;
+    }
+
+    public static string FormatPlayerNameWorld(string playerName, string? worldName, string? fallbackName = null) {
+        playerName = NormalizeWorldSeparator(playerName);
+        worldName = NormalizeWorldSeparator(worldName ?? string.Empty);
+        fallbackName = NormalizeWorldSeparator(fallbackName ?? string.Empty);
+
+        if (playerName.Length > 0 && worldName.Length > 0)
+            return $"{playerName}@{worldName}";
+
+        if (fallbackName.Length > 0)
+            return fallbackName;
+
+        return playerName;
+    }
+
+    public static int MatchScore(string configName, string actorName) {
+        configName = NormalizeWorldSeparator(configName);
+        actorName = NormalizeWorldSeparator(actorName);
+
+        if (string.Equals(configName, actorName, StringComparison.OrdinalIgnoreCase))
+            return int.MaxValue;
+
+        var configBaseName = GetBaseCharacterName(configName);
+        var actorBaseName = GetBaseCharacterName(actorName);
+
+        if (string.Equals(configBaseName, actorBaseName, StringComparison.OrdinalIgnoreCase))
+            return int.MaxValue - 1;
+
+        if (actorBaseName.Contains(configBaseName, StringComparison.OrdinalIgnoreCase))
+            return configBaseName.Length;
+
+        if (configBaseName.Contains(actorBaseName, StringComparison.OrdinalIgnoreCase))
+            return actorBaseName.Length;
+
+        return -1;
+    }
+
+    public static string GetBaseCharacterName(string fullName) {
+        fullName = NormalizeWorldSeparator(fullName);
+        if (fullName.Length == 0)
+            return string.Empty;
+
+        var atIndex = fullName.LastIndexOf('@');
+        return atIndex >= 0 ? fullName[..atIndex].Trim() : fullName.Trim();
+    }
+}

--- a/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
+++ b/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
@@ -21,10 +21,11 @@ public static class FormationLocalMovementExecutor {
             return false;
         }
 
-        return ExecutePointOneAnchoredMove(
+        return ExecuteAnchoredMove(
             plugin,
             formation,
             destinationPointIndex,
+            FormationPointMovement.AnchorPointIndex,
             resolvedAnchor.Position,
             resolvedAnchor.Rotation,
             movementMode,
@@ -47,37 +48,50 @@ public static class FormationLocalMovementExecutor {
             return false;
         }
 
-        if (anchor.Kind == FormationAnchorKind.Default && destinationPointIndex == FormationPointMovement.AnchorPointIndex) {
-            DalamudApi.PluginLog.Debug($"[{logPrefix}] local character is point 1 anchor for formation \"{formationName}\"; no movement needed");
-            return true;
-        }
-
         if (!FormationAnchorResolver.TryResolve(plugin, formation, anchor, out var resolvedAnchor, out var anchorFailure, out var failureKind)) {
             LogAnchorFailure(logPrefix, anchorFailure, failureKind);
             return false;
         }
 
-        return ExecutePointOneAnchoredMove(
+        var anchorPointIndex = FormationPointMovement.AnchorPointIndex;
+        if (anchor.Kind != FormationAnchorKind.Self) {
+            var anchorCid = resolvedAnchor.ContentId;
+            if (anchorCid == localCid) {
+                DalamudApi.PluginLog.Debug($"[{logPrefix}] local character is the formation anchor for \"{formationName}\"; no movement needed");
+                return true;
+            }
+
+            if (anchorCid.HasValue) {
+                var assignedAnchorPointIndex = FormationExecution.GetAssignedPointIndex(formation, anchorCid.Value, plugin.Config.CidsGroups);
+                if (assignedAnchorPointIndex >= 0)
+                    anchorPointIndex = assignedAnchorPointIndex;
+            }
+        }
+
+        return ExecuteAnchoredMove(
             plugin,
             formation,
             destinationPointIndex,
+            anchorPointIndex,
             resolvedAnchor.Position,
             resolvedAnchor.Rotation,
             movementMode,
             logPrefix);
     }
 
-    public static bool ExecutePointOneAnchoredMove(
+    public static bool ExecuteAnchoredMove(
         Plugin plugin,
         Formation formation,
         int destinationPointIndex,
+        int anchorPointIndex,
         Vector3 anchorWorldPosition,
         float anchorWorldRotation,
         SimpleMovementMode movementMode,
         string logPrefix) {
-        var move = FormationPointMovement.BuildPointOneAnchoredWorldMove(
+        var move = FormationPointMovement.BuildAnchoredWorldMove(
             formation,
             destinationPointIndex,
+            anchorPointIndex,
             anchorWorldPosition,
             anchorWorldRotation);
         if (move == null) {

--- a/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
+++ b/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
@@ -53,18 +53,12 @@ public static class FormationLocalMovementExecutor {
             return false;
         }
 
-        var anchorPointIndex = FormationPointMovement.AnchorPointIndex;
+        var anchorPointIndex = ResolveAnchorPointIndex(formation, plugin.Config.CidsGroups, anchor, resolvedAnchor.ContentId, localCid);
         if (anchor.Kind != FormationAnchorKind.Self) {
             var anchorCid = resolvedAnchor.ContentId;
             if (anchorCid == localCid) {
                 DalamudApi.PluginLog.Debug($"[{logPrefix}] local character is the formation anchor for \"{formationName}\"; no movement needed");
                 return true;
-            }
-
-            if (anchorCid.HasValue) {
-                var assignedAnchorPointIndex = FormationExecution.GetAssignedPointIndex(formation, anchorCid.Value, plugin.Config.CidsGroups);
-                if (assignedAnchorPointIndex >= 0)
-                    anchorPointIndex = assignedAnchorPointIndex;
             }
         }
 
@@ -77,6 +71,25 @@ public static class FormationLocalMovementExecutor {
             resolvedAnchor.Rotation,
             movementMode,
             logPrefix);
+    }
+
+    public static int ResolveAnchorPointIndex(
+        Formation formation,
+        System.Collections.Generic.IReadOnlyList<CidGroup>? groups,
+        FormationAnchorReference anchor,
+        ulong? anchorCid,
+        ulong localCid) {
+        if (anchor.Kind == FormationAnchorKind.Self)
+            return FormationPointMovement.AnchorPointIndex;
+
+        if (anchorCid == localCid)
+            return FormationPointMovement.AnchorPointIndex;
+
+        if (!anchorCid.HasValue)
+            return FormationPointMovement.AnchorPointIndex;
+
+        var assignedAnchorPointIndex = FormationExecution.GetAssignedPointIndex(formation, anchorCid.Value, groups);
+        return assignedAnchorPointIndex >= 0 ? assignedAnchorPointIndex : FormationPointMovement.AnchorPointIndex;
     }
 
     public static bool ExecuteAnchoredMove(

--- a/MasterOfPuppets/Formations/FormationPointMovement.cs
+++ b/MasterOfPuppets/Formations/FormationPointMovement.cs
@@ -9,16 +9,17 @@ namespace MasterOfPuppets.Formations;
 public static class FormationPointMovement {
     public const int AnchorPointIndex = 0;
 
-    public static (Vector3 Position, float Rotation)? BuildPointOneAnchoredWorldMove(
+    public static (Vector3 Position, float Rotation)? BuildAnchoredWorldMove(
         Formation formation,
         int destinationPointIndex,
+        int anchorPointIndex,
         Vector3 anchorWorldPosition,
         float anchorWorldRotation) {
-        if (!formation.Points.IndexExists(AnchorPointIndex) || !formation.Points.IndexExists(destinationPointIndex))
+        if (!formation.Points.IndexExists(anchorPointIndex) || !formation.Points.IndexExists(destinationPointIndex))
             return null;
 
         return FormationMath.GetMopRelativeWorld(
-            formation.Points[AnchorPointIndex],
+            formation.Points[anchorPointIndex],
             formation.Points[destinationPointIndex],
             anchorWorldPosition,
             anchorWorldRotation);
@@ -57,6 +58,6 @@ public static class FormationPointMovement {
         destinationPointIndex = FormationExecution.GetAssignedPointIndex(formation, destinationContentId, groups);
         return destinationPointIndex < 0
             ? null
-            : BuildPointOneAnchoredWorldMove(formation, destinationPointIndex, anchorWorldPosition, anchorWorldRotation);
+            : BuildAnchoredWorldMove(formation, destinationPointIndex, AnchorPointIndex, anchorWorldPosition, anchorWorldRotation);
     }
 }

--- a/MasterOfPuppets/Game/ChatWatcher.cs
+++ b/MasterOfPuppets/Game/ChatWatcher.cs
@@ -4,9 +4,12 @@ using System.Linq;
 
 using Dalamud.Game.Chat;
 using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 
 using MasterOfPuppets.Formations;
 using MasterOfPuppets.Util;
+using Lumina.Text.ReadOnly;
 
 namespace MasterOfPuppets;
 
@@ -83,11 +86,11 @@ internal class ChatWatcher : IDisposable {
         if (message.IsHandled)
             return;
 
-        var senderName = SanitizeSenderName(message.Sender.ToString());
+        var senderName = GetSenderName(message);
 
         if (!AllowedChatTypes.Contains(message.LogKind)
             || !Plugin.Config.ListenedChatTypes.Contains(message.LogKind)
-            || (Plugin.Config.UseChatCommandSenderWhitelist && !Plugin.Config.ChatCommandSenderWhitelist.Contains(senderName))
+            || !IsAllowedSender(senderName)
         ) {
             return;
         }
@@ -226,5 +229,52 @@ internal class ChatWatcher : IDisposable {
         var i = 0;
         while (i < raw.Length && !char.IsLetter(raw[i])) i++;
         return i > 0 ? raw[i..] : raw;
+    }
+
+    private bool IsAllowedSender(string senderName) {
+        if (!Plugin.Config.UseChatCommandSenderWhitelist)
+            return true;
+
+        return Plugin.Config.ChatCommandSenderWhitelist.Any(allowed =>
+            string.Equals(
+                FormationCharacterName.NormalizeWorldSeparator(allowed),
+                senderName,
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string GetSenderName(IChatMessage message) {
+        var senderName = GetPlayerPayloadSenderName(message.Sender);
+        if (!string.IsNullOrWhiteSpace(senderName))
+            return senderName;
+
+        senderName = GetExtractedSenderName(message.OriginalSender);
+        if (!string.IsNullOrWhiteSpace(senderName))
+            return senderName;
+
+        return GetSenderTextName(message.Sender);
+    }
+
+    private static string GetPlayerPayloadSenderName(SeString sender) {
+        foreach (var payload in sender.Payloads.OfType<PlayerPayload>()) {
+            var formattedName = FormationCharacterName.FormatPlayerNameWorld(
+                payload.PlayerName,
+                payload.World.ValueNullable?.Name.ToString(),
+                payload.DisplayedName);
+
+            if (!string.IsNullOrWhiteSpace(formattedName))
+                return formattedName;
+        }
+
+        return string.Empty;
+    }
+
+    private static string GetExtractedSenderName(ReadOnlySeString sender) =>
+        FormationCharacterName.NormalizeWorldSeparator(SanitizeSenderName(sender.ExtractText()));
+
+    private static string GetSenderTextName(SeString sender) {
+        var senderName = FormationCharacterName.NormalizeWorldSeparator(SanitizeSenderName(sender.TextValue));
+        return !string.IsNullOrWhiteSpace(senderName)
+            ? senderName
+            : FormationCharacterName.NormalizeWorldSeparator(SanitizeSenderName(sender.ToString()));
     }
 }

--- a/MasterOfPuppets/Game/ChatWatcher.cs
+++ b/MasterOfPuppets/Game/ChatWatcher.cs
@@ -198,10 +198,14 @@ internal class ChatWatcher : IDisposable {
 
         var anchor = FormationAnchorArgumentParser.ParseAnchorAndArrival(
             args.Skip(1),
-            FormationAnchorReference.Default);
+            FormationAnchorReference.Sender);
         if (anchor.InvalidArgument != null) {
             DalamudApi.ChatGui.PrintError($"Invalid command argument: {anchor.InvalidArgument}");
             return;
+        }
+
+        if (anchor.Anchor.Kind == FormationAnchorKind.Sender && string.IsNullOrWhiteSpace(anchor.Anchor.Name)) {
+            anchor = anchor with { Anchor = anchor.Anchor with { Name = senderName } };
         }
 
         if (anchor.Anchor.Kind == FormationAnchorKind.FocusTarget) {

--- a/MasterOfPuppets/Game/Login/AutoLoginDialogMatcher.cs
+++ b/MasterOfPuppets/Game/Login/AutoLoginDialogMatcher.cs
@@ -18,7 +18,14 @@ public static class AutoLoginDialogMatcher {
         if (string.IsNullOrWhiteSpace(text))
             return false;
 
-        return Normalize(text).Contains(Normalize(TextLastLoggedOut.ToString()), StringComparison.OrdinalIgnoreCase);
+        return MatchesDialog(text, TextLastLoggedOut.ToString());
+    }
+
+    public static bool MatchesDialog(string text, string reference) {
+        if (string.IsNullOrWhiteSpace(text) || string.IsNullOrWhiteSpace(reference))
+            return false;
+
+        return Normalize(text).Contains(Normalize(reference), StringComparison.OrdinalIgnoreCase);
     }
 
     private static string Normalize(string text) =>

--- a/MasterOfPuppets/MopMacro/CommandHelp/MopCommandsHelper.ChatSync.cs
+++ b/MasterOfPuppets/MopMacro/CommandHelp/MopCommandsHelper.ChatSync.cs
@@ -112,7 +112,7 @@ public static partial class MopCommandsHelper {
         },
         new MopAction {
             Category = MopActionCategory.ChatSyncCommand,
-            TextCommand = "mopformation \"Formation Name\" [self|target|\"Character Name\"|\"Character Name@World\"] [continuous|precise]",
+            TextCommand = "mopformation \"Formation Name\" [sender|default|self|target|\"Character Name\"|\"Character Name@World\"] [continuous|precise]",
             SuggestionCommand = "mopformation ",
             Example = """
             Move each chat-sync client to its assigned point in a shared formation:
@@ -122,7 +122,8 @@ public static partial class MopCommandsHelper {
             """,
             Notes = """
             * This is a chat sync command - all clients reading the chat resolve and move only their local character.
-            * Without an explicit anchor, point 1's assigned character is used as the live anchor and must be visible.
+            * Without an explicit anchor, the chat sender is used as the live anchor and must be visible.
+            * Use default to anchor on point 1's assigned character.
             * Default: precise. Use continuous for smoother loops.
             * All clients need the same formation imported or configured.
             """

--- a/MasterOfPuppets/Ui/Windows/SettingsWindow/SettingsWindow.cs
+++ b/MasterOfPuppets/Ui/Windows/SettingsWindow/SettingsWindow.cs
@@ -394,7 +394,8 @@ public class SettingsWindow : Window {
                 mopformation "formation name"
                 mopstop
 
-            Formation chat sync uses point 1's assigned character as the default live anchor.
+            Formation chat sync uses the chat sender as the default live anchor.
+            Use the default anchor argument to use point 1's assigned character instead.
             All clients need the same formation and the anchor character must be visible.
             """);
 

--- a/MasterOfPuppetsTests/AutoLoginDialogMatcherTests.cs
+++ b/MasterOfPuppetsTests/AutoLoginDialogMatcherTests.cs
@@ -5,6 +5,9 @@ using Xunit;
 namespace MasterOfPuppetsTests;
 
 public class AutoLoginDialogMatcherTests {
+    private const string MissingLastLoggedOutReference =
+        "The character you last logged out with in this play environment could not be found on the current data center.Please connect to another data center from the Data Center Selection screen.";
+
     [Fact]
     public void IsMissingLastLoggedOutCharacterSelectOk_MatchesKnownPreLoginDialog() {
         var text = """
@@ -12,7 +15,7 @@ public class AutoLoginDialogMatcherTests {
                    current data center.Please connect to another data center from the Data Center Selection screen.
                    """;
 
-        Assert.True(AutoLoginDialogMatcher.IsMissingLastLoggedOutCharacterSelectOk(text));
+        Assert.True(AutoLoginDialogMatcher.MatchesDialog(text, MissingLastLoggedOutReference));
     }
 
     [Fact]
@@ -22,6 +25,6 @@ public class AutoLoginDialogMatcherTests {
                    Players in queue: 15.
                    """;
 
-        Assert.False(AutoLoginDialogMatcher.IsMissingLastLoggedOutCharacterSelectOk(text));
+        Assert.False(AutoLoginDialogMatcher.MatchesDialog(text, MissingLastLoggedOutReference));
     }
 }

--- a/MasterOfPuppetsTests/FormationExecutionTests.cs
+++ b/MasterOfPuppetsTests/FormationExecutionTests.cs
@@ -395,6 +395,104 @@ public class FormationExecutionTests
         Assert.Equal("sender", FormationAnchorArgumentParser.FormatForMacro(FormationAnchorReference.Sender));
     }
 
+    [Fact]
+    public void FormationCharacterName_Normalizes_CrossWorld_Separator() {
+        Assert.Equal(
+            "Punching Baggins@Diabolos",
+            FormationCharacterName.NormalizeWorldSeparator("Punching Baggins\uE0B2Diabolos"));
+    }
+
+    [Fact]
+    public void FormationCharacterName_Normalizes_CrossWorld_Prefix() {
+        Assert.Equal(
+            "Punching Baggins@Diabolos",
+            FormationCharacterName.NormalizeWorldSeparator("Punching Baggins\uE0B1Diabolos"));
+    }
+
+    [Fact]
+    public void FormationCharacterName_Collapses_Repeated_World_Separators() {
+        Assert.Equal(
+            "Punching Baggins@Diabolos",
+            FormationCharacterName.NormalizeWorldSeparator("Punching Baggins \uE0B1\uE0B2 Diabolos"));
+    }
+
+    [Theory]
+    [InlineData("Kicking Sackins", "Kicking Sackins")]
+    [InlineData("Kicking Sackins@Golem", "Kicking Sackins@Golem")]
+    public void FormationCharacterName_Keeps_Normal_Names(string input, string expected) {
+        Assert.Equal(expected, FormationCharacterName.NormalizeWorldSeparator(input));
+    }
+
+    [Fact]
+    public void FormationCharacterName_Matches_CrossWorld_Sender_To_Configured_Name() {
+        var score = FormationCharacterName.MatchScore(
+            "Punching Baggins@Diabolos",
+            "Punching Baggins\uE0B2Diabolos");
+
+        Assert.Equal(int.MaxValue, score);
+    }
+
+    [Fact]
+    public void FormationCharacterName_Matches_SameWorld_Sender_By_Base_Name() {
+        var score = FormationCharacterName.MatchScore(
+            "Kicking Sackins@Golem",
+            "Kicking Sackins");
+
+        Assert.Equal(int.MaxValue - 1, score);
+    }
+
+    [Fact]
+    public void FormationCharacterName_Formats_PlayerPayload_Name_And_World() {
+        Assert.Equal(
+            "Punching Baggins@Diabolos",
+            FormationCharacterName.FormatPlayerNameWorld("Punching Baggins", "Diabolos", "ignored"));
+    }
+
+    [Fact]
+    public void FormationCharacterName_Formats_PlayerPayload_Fallback_When_World_Missing() {
+        Assert.Equal(
+            "Punching Baggins@Diabolos",
+            FormationCharacterName.FormatPlayerNameWorld("Punching Baggins", null, "Punching Baggins\uE0B2Diabolos"));
+    }
+
+    [Fact]
+    public void FormationLocalMovementExecutor_Resolves_Sender_Anchor_Point_From_Cid() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Cids = [100] },
+                new FormationPoint { Cids = [101] },
+            ],
+        };
+
+        var anchorPointIndex = FormationLocalMovementExecutor.ResolveAnchorPointIndex(
+            formation,
+            groups: null,
+            FormationAnchorReference.Sender with { Name = "Kicking Sackins@Golem" },
+            anchorCid: 101,
+            localCid: 100);
+
+        Assert.Equal(1, anchorPointIndex);
+    }
+
+    [Fact]
+    public void FormationLocalMovementExecutor_Falls_Back_To_Point_One_When_Sender_Cid_Is_Unassigned() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Cids = [100] },
+                new FormationPoint { Cids = [101] },
+            ],
+        };
+
+        var anchorPointIndex = FormationLocalMovementExecutor.ResolveAnchorPointIndex(
+            formation,
+            groups: null,
+            FormationAnchorReference.Sender,
+            anchorCid: 999,
+            localCid: 100);
+
+        Assert.Equal(FormationPointMovement.AnchorPointIndex, anchorPointIndex);
+    }
+
     private static void AssertClose(float expected, float actual, float tolerance = 0.0001f) =>
         Assert.InRange(MathF.Abs(expected - actual), 0f, tolerance);
 }

--- a/MasterOfPuppetsTests/FormationExecutionTests.cs
+++ b/MasterOfPuppetsTests/FormationExecutionTests.cs
@@ -398,27 +398,27 @@ public class FormationExecutionTests
     [Fact]
     public void FormationCharacterName_Normalizes_CrossWorld_Separator() {
         Assert.Equal(
-            "Punching Baggins@Diabolos",
-            FormationCharacterName.NormalizeWorldSeparator("Punching Baggins\uE0B2Diabolos"));
+            "Alpha One@ServerA",
+            FormationCharacterName.NormalizeWorldSeparator("Alpha One\uE0B2ServerA"));
     }
 
     [Fact]
     public void FormationCharacterName_Normalizes_CrossWorld_Prefix() {
         Assert.Equal(
-            "Punching Baggins@Diabolos",
-            FormationCharacterName.NormalizeWorldSeparator("Punching Baggins\uE0B1Diabolos"));
+            "Alpha One@ServerA",
+            FormationCharacterName.NormalizeWorldSeparator("Alpha One\uE0B1ServerA"));
     }
 
     [Fact]
     public void FormationCharacterName_Collapses_Repeated_World_Separators() {
         Assert.Equal(
-            "Punching Baggins@Diabolos",
-            FormationCharacterName.NormalizeWorldSeparator("Punching Baggins \uE0B1\uE0B2 Diabolos"));
+            "Alpha One@ServerA",
+            FormationCharacterName.NormalizeWorldSeparator("Alpha One \uE0B1\uE0B2 ServerA"));
     }
 
     [Theory]
-    [InlineData("Kicking Sackins", "Kicking Sackins")]
-    [InlineData("Kicking Sackins@Golem", "Kicking Sackins@Golem")]
+    [InlineData("Bravo Two", "Bravo Two")]
+    [InlineData("Bravo Two@ServerB", "Bravo Two@ServerB")]
     public void FormationCharacterName_Keeps_Normal_Names(string input, string expected) {
         Assert.Equal(expected, FormationCharacterName.NormalizeWorldSeparator(input));
     }
@@ -426,8 +426,8 @@ public class FormationExecutionTests
     [Fact]
     public void FormationCharacterName_Matches_CrossWorld_Sender_To_Configured_Name() {
         var score = FormationCharacterName.MatchScore(
-            "Punching Baggins@Diabolos",
-            "Punching Baggins\uE0B2Diabolos");
+            "Alpha One@ServerA",
+            "Alpha One\uE0B2ServerA");
 
         Assert.Equal(int.MaxValue, score);
     }
@@ -435,8 +435,8 @@ public class FormationExecutionTests
     [Fact]
     public void FormationCharacterName_Matches_SameWorld_Sender_By_Base_Name() {
         var score = FormationCharacterName.MatchScore(
-            "Kicking Sackins@Golem",
-            "Kicking Sackins");
+            "Bravo Two@ServerB",
+            "Bravo Two");
 
         Assert.Equal(int.MaxValue - 1, score);
     }
@@ -444,15 +444,15 @@ public class FormationExecutionTests
     [Fact]
     public void FormationCharacterName_Formats_PlayerPayload_Name_And_World() {
         Assert.Equal(
-            "Punching Baggins@Diabolos",
-            FormationCharacterName.FormatPlayerNameWorld("Punching Baggins", "Diabolos", "ignored"));
+            "Alpha One@ServerA",
+            FormationCharacterName.FormatPlayerNameWorld("Alpha One", "ServerA", "ignored"));
     }
 
     [Fact]
     public void FormationCharacterName_Formats_PlayerPayload_Fallback_When_World_Missing() {
         Assert.Equal(
-            "Punching Baggins@Diabolos",
-            FormationCharacterName.FormatPlayerNameWorld("Punching Baggins", null, "Punching Baggins\uE0B2Diabolos"));
+            "Alpha One@ServerA",
+            FormationCharacterName.FormatPlayerNameWorld("Alpha One", null, "Alpha One\uE0B2ServerA"));
     }
 
     [Fact]
@@ -467,7 +467,7 @@ public class FormationExecutionTests
         var anchorPointIndex = FormationLocalMovementExecutor.ResolveAnchorPointIndex(
             formation,
             groups: null,
-            FormationAnchorReference.Sender with { Name = "Kicking Sackins@Golem" },
+            FormationAnchorReference.Sender with { Name = "Bravo Two@ServerB" },
             anchorCid: 101,
             localCid: 100);
 

--- a/MasterOfPuppetsTests/FormationExecutionTests.cs
+++ b/MasterOfPuppetsTests/FormationExecutionTests.cs
@@ -219,9 +219,10 @@ public class FormationExecutionTests
             ],
         };
 
-        var move = FormationPointMovement.BuildPointOneAnchoredWorldMove(
+        var move = FormationPointMovement.BuildAnchoredWorldMove(
             formation,
             destinationPointIndex: 1,
+            anchorPointIndex: FormationPointMovement.AnchorPointIndex,
             anchorWorldPosition: new Vector3(10f, 0f, 20f),
             anchorWorldRotation: MathF.PI / 2f);
 
@@ -249,9 +250,10 @@ public class FormationExecutionTests
             formation.Points[1],
             anchorPosition,
             anchorRotation);
-        var helper = FormationPointMovement.BuildPointOneAnchoredWorldMove(
+        var helper = FormationPointMovement.BuildAnchoredWorldMove(
             formation,
             destinationPointIndex: 1,
+            anchorPointIndex: FormationPointMovement.AnchorPointIndex,
             anchorPosition,
             anchorRotation);
 
@@ -319,6 +321,78 @@ public class FormationExecutionTests
         AssertClose(12f, move.Value.Position.X);
         AssertClose(20f, move.Value.Position.Z);
         AssertClose(0f, move.Value.Rotation);
+    }
+
+    [Fact]
+    public void FormationPointMovement_UsesFlexibleAnchorPoint() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Offset = new Vector3(0f, 0f, 0f), Angle = 0f },
+                new FormationPoint { Offset = new Vector3(0f, 0f, 2f), Angle = 180f },
+                new FormationPoint { Offset = new Vector3(2f, 0f, 0f), Angle = 90f },
+            ],
+        };
+
+        var move = FormationPointMovement.BuildAnchoredWorldMove(
+            formation,
+            destinationPointIndex: 1,
+            anchorPointIndex: 2,
+            anchorWorldPosition: new Vector3(10f, 0f, 20f),
+            anchorWorldRotation: 0f);
+
+        Assert.NotNull(move);
+        AssertClose(8f, move.Value.Position.X);
+        AssertClose(22f, move.Value.Position.Z);
+        AssertClose(MathF.PI / 2f, move.Value.Rotation);
+    }
+
+    [Fact]
+    public void FormationPointMovement_FlexibleAnchor_KeepsAnchorAtItsOwnPosition() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Offset = new Vector3(0f, 0f, 0f), Angle = 0f },
+                new FormationPoint { Offset = new Vector3(0f, 0f, 2f), Angle = 180f },
+                new FormationPoint { Offset = new Vector3(2f, 0f, 0f), Angle = 90f },
+            ],
+        };
+
+        var anchorPosition = new Vector3(10f, 0f, 20f);
+        var anchorRotation = MathF.PI / 4f;
+
+        var move = FormationPointMovement.BuildAnchoredWorldMove(
+            formation,
+            destinationPointIndex: 2,
+            anchorPointIndex: 2,
+            anchorWorldPosition: anchorPosition,
+            anchorWorldRotation: anchorRotation);
+
+        Assert.NotNull(move);
+        AssertClose(anchorPosition.X, move.Value.Position.X);
+        AssertClose(anchorPosition.Z, move.Value.Position.Z);
+        AssertClose(anchorRotation, move.Value.Rotation);
+    }
+
+    [Fact]
+    public void FormationAnchorArgumentParser_ParsesSender() {
+        var result = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            ["sender"],
+            FormationAnchorReference.Self);
+
+        Assert.Equal(FormationAnchorKind.Sender, result.Anchor.Kind);
+    }
+
+    [Fact]
+    public void FormationAnchorArgumentParser_DefaultsToSender() {
+        var result = FormationAnchorArgumentParser.ParseAnchorAndArrival(
+            [],
+            FormationAnchorReference.Sender);
+
+        Assert.Equal(FormationAnchorKind.Sender, result.Anchor.Kind);
+    }
+
+    [Fact]
+    public void FormationAnchorArgumentParser_FormatsSenderForMacro() {
+        Assert.Equal("sender", FormationAnchorArgumentParser.FormatForMacro(FormationAnchorReference.Sender));
     }
 
     private static void AssertClose(float expected, float actual, float tolerance = 0.0001f) =>


### PR DESCRIPTION
Changes the default anchor for the chat-sync `mopformation` command from point 1 to the chat sender.

The sender name is now resolved via `PlayerPayload` in the SeString, which provides structured name and world data instead of relying on raw text parsing that breaks on the FFXIV private-use world separator characters (`\uE0B1`, `\uE0B2`).

### Key changes
- **`ChatWatcher.HandleFormationCommand`**: default anchor changed from `Default` (point 1) to `Sender`.
- **`GetSenderName`**: extracts sender info from `PlayerPayload` first, then falls back to `ExtractText()` and `TextValue`/`ToString()` with separator normalization.
- **`FormationCharacterName`** (new): provides `NormalizeWorldSeparator` (replaces `\uE0B1`/`\uE0B2` with `@`), `FormatPlayerNameWorld`, and `MatchScore` for consistent cross-world name handling throughout the resolution pipeline.
- **`ResolveAnchorPointIndex`** extracted into a reusable method in `FormationLocalMovementExecutor`.
- **Docs/help** updated to reflect the new sender-anchor default and the `default` keyword for point-1 fallback.
- **Tests** cover cross-world separator normalization, PlayerPayload formatting, same-world base name matching, and anchor-point-index resolution.

### Fixes
- `mopformation "Formation Name"` now correctly resolves cross-world senders whose names include the FFXIV world icon separator.
- Sender-whitelist comparison normalizes separators before matching.