### PR TITLE
Preserve formation frame rotation when anchoring on assigned characters

### DIFF
--- a/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
+++ b/MasterOfPuppets/Formations/FormationLocalMovementExecutor.cs
@@ -53,6 +53,9 @@ public static class FormationLocalMovementExecutor {
             return false;
         }
 
+        var assignedAnchorPointIndex = resolvedAnchor.ContentId.HasValue
+            ? FormationExecution.GetAssignedPointIndex(formation, resolvedAnchor.ContentId.Value, plugin.Config.CidsGroups)
+            : -1;
         var anchorPointIndex = ResolveAnchorPointIndex(formation, plugin.Config.CidsGroups, anchor, resolvedAnchor.ContentId, localCid);
         if (anchor.Kind != FormationAnchorKind.Self) {
             var anchorCid = resolvedAnchor.ContentId;
@@ -62,13 +65,18 @@ public static class FormationLocalMovementExecutor {
             }
         }
 
+        var anchorRotation = ResolveAnchorFrameRotation(
+            formation,
+            anchorPointIndex,
+            resolvedAnchor.Rotation,
+            ShouldNormalizeAssignedAnchorRotation(anchor, resolvedAnchor.ContentId, localCid, assignedAnchorPointIndex));
         return ExecuteAnchoredMove(
             plugin,
             formation,
             destinationPointIndex,
             anchorPointIndex,
             resolvedAnchor.Position,
-            resolvedAnchor.Rotation,
+            anchorRotation,
             movementMode,
             logPrefix);
     }
@@ -91,6 +99,27 @@ public static class FormationLocalMovementExecutor {
         var assignedAnchorPointIndex = FormationExecution.GetAssignedPointIndex(formation, anchorCid.Value, groups);
         return assignedAnchorPointIndex >= 0 ? assignedAnchorPointIndex : FormationPointMovement.AnchorPointIndex;
     }
+
+    public static float ResolveAnchorFrameRotation(
+        Formation formation,
+        int anchorPointIndex,
+        float anchorActorRotation,
+        bool normalizeAssignedAnchorRotation) {
+        if (!normalizeAssignedAnchorRotation || anchorPointIndex < 0 || anchorPointIndex >= formation.Points.Count)
+            return anchorActorRotation;
+
+        return FormationMath.GetFormationFrameRotation(formation.Points[anchorPointIndex], anchorActorRotation);
+    }
+
+    private static bool ShouldNormalizeAssignedAnchorRotation(
+        FormationAnchorReference anchor,
+        ulong? anchorCid,
+        ulong localCid,
+        int assignedAnchorPointIndex) =>
+        anchor.Kind != FormationAnchorKind.Self
+        && anchorCid.HasValue
+        && anchorCid.Value != localCid
+        && assignedAnchorPointIndex >= 0;
 
     public static bool ExecuteAnchoredMove(
         Plugin plugin,

--- a/MasterOfPuppets/Formations/FormationMath.cs
+++ b/MasterOfPuppets/Formations/FormationMath.cs
@@ -29,9 +29,8 @@ public static class FormationMath {
         Vector3 anchorWorldPosition,
         float anchorWorldRotation) {
         var memberRelativeToAnchor = memberPoint.Offset - anchorPoint.Offset;
-        var memberRotationRelativeToAnchor = NormalizeDegrees(memberPoint.Angle - anchorPoint.Angle);
         var worldPosition = memberRelativeToAnchor.ApplyLeaderRotation(anchorWorldRotation, anchorWorldPosition);
-        var worldRotation = anchorWorldRotation + memberRotationRelativeToAnchor * Angle.DegToRad;
+        var worldRotation = anchorWorldRotation + memberPoint.Angle * Angle.DegToRad;
 
         return (worldPosition, worldRotation);
     }

--- a/MasterOfPuppets/Formations/FormationMath.cs
+++ b/MasterOfPuppets/Formations/FormationMath.cs
@@ -35,6 +35,9 @@ public static class FormationMath {
         return (worldPosition, worldRotation);
     }
 
+    public static float GetFormationFrameRotation(FormationPoint anchorPoint, float anchorActorRotation) =>
+        anchorActorRotation - anchorPoint.Angle * Angle.DegToRad;
+
     public static float NormalizeDegrees(float degrees) {
         while (degrees < -180f)
             degrees += 360f;

--- a/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
+++ b/MasterOfPuppets/Ipc/IpcProvider.Formation.cs
@@ -267,9 +267,18 @@ internal partial class IpcProvider {
             return false;
         }
 
+        cid = resolved.ContentId ?? issuerCid;
         position = resolved.Position;
         rotation = resolved.Rotation;
-        cid = issuerCid;
+
+        if (ShouldNormalizeAssignedAnchorRotation(anchor) && GetAssignedPoint(formation, cid) is { } anchorPoint)
+            rotation = FormationMath.GetFormationFrameRotation(anchorPoint, resolved.Rotation);
+
         return cid != 0;
     }
+
+    private static bool ShouldNormalizeAssignedAnchorRotation(FormationAnchorReference anchor) =>
+        anchor.Kind is FormationAnchorKind.Self
+            or FormationAnchorKind.Sender
+            or FormationAnchorKind.Named;
 }

--- a/MasterOfPuppetsTests/FormationExecutionTests.cs
+++ b/MasterOfPuppetsTests/FormationExecutionTests.cs
@@ -112,11 +112,11 @@ public class FormationExecutionTests
 
         AssertClose(targetPosition.X, issuerWorldPosition.X);
         AssertClose(targetPosition.Z, issuerWorldPosition.Z);
-        AssertClose(targetRotation, issuerWorldRotation);
+        AssertClose(targetRotation + 45f * Angle.DegToRad, issuerWorldRotation);
 
         AssertClose(12f, memberWorldPosition.X);
         AssertClose(20f, memberWorldPosition.Z);
-        AssertClose(0f, memberWorldRotation);
+        AssertClose(MathF.PI / 4f, memberWorldRotation);
     }
 
     [Fact]
@@ -229,7 +229,7 @@ public class FormationExecutionTests
         Assert.NotNull(move);
         AssertClose(12f, move.Value.Position.X);
         AssertClose(20f, move.Value.Position.Z);
-        AssertClose(0f, move.Value.Rotation);
+        AssertClose(MathF.PI / 4f, move.Value.Rotation);
     }
 
     [Fact]
@@ -320,7 +320,7 @@ public class FormationExecutionTests
         Assert.Equal(1, destinationPointIndex);
         AssertClose(12f, move.Value.Position.X);
         AssertClose(20f, move.Value.Position.Z);
-        AssertClose(0f, move.Value.Rotation);
+        AssertClose(MathF.PI / 4f, move.Value.Rotation);
     }
 
     [Fact]
@@ -343,7 +343,7 @@ public class FormationExecutionTests
         Assert.NotNull(move);
         AssertClose(8f, move.Value.Position.X);
         AssertClose(22f, move.Value.Position.Z);
-        AssertClose(MathF.PI / 2f, move.Value.Rotation);
+        AssertClose(MathF.PI, move.Value.Rotation);
     }
 
     [Fact]
@@ -369,7 +369,52 @@ public class FormationExecutionTests
         Assert.NotNull(move);
         AssertClose(anchorPosition.X, move.Value.Position.X);
         AssertClose(anchorPosition.Z, move.Value.Position.Z);
-        AssertClose(anchorRotation, move.Value.Rotation);
+        AssertClose(anchorRotation + MathF.PI / 2f, move.Value.Rotation);
+    }
+
+    [Fact]
+    public void FormationPointMovement_FlexibleAnchor_PreservesPositionAndUsesMemberFacing() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Offset = new Vector3(0f, 0f, 0f), Angle = 0f },
+                new FormationPoint { Offset = new Vector3(0f, 0f, 2f), Angle = 180f },
+                new FormationPoint { Offset = new Vector3(2f, 0f, 0f), Angle = 90f },
+            ],
+        };
+        var anchorPosition = new Vector3(10f, 0f, 20f);
+        var anchorRotation = 0.25f;
+
+        var centerMove = FormationPointMovement.BuildAnchoredWorldMove(
+            formation,
+            destinationPointIndex: 0,
+            anchorPointIndex: 2,
+            anchorWorldPosition: anchorPosition,
+            anchorWorldRotation: anchorRotation);
+        var rearMove = FormationPointMovement.BuildAnchoredWorldMove(
+            formation,
+            destinationPointIndex: 1,
+            anchorPointIndex: 2,
+            anchorWorldPosition: anchorPosition,
+            anchorWorldRotation: anchorRotation);
+
+        var expectedCenterPosition = ApplyLeaderRotation(
+            formation.Points[0].Offset - formation.Points[2].Offset,
+            anchorRotation,
+            anchorPosition);
+        var expectedRearPosition = ApplyLeaderRotation(
+            formation.Points[1].Offset - formation.Points[2].Offset,
+            anchorRotation,
+            anchorPosition);
+
+        Assert.NotNull(centerMove);
+        AssertClose(expectedCenterPosition.X, centerMove.Value.Position.X);
+        AssertClose(expectedCenterPosition.Z, centerMove.Value.Position.Z);
+        AssertClose(anchorRotation, centerMove.Value.Rotation);
+
+        Assert.NotNull(rearMove);
+        AssertClose(expectedRearPosition.X, rearMove.Value.Position.X);
+        AssertClose(expectedRearPosition.Z, rearMove.Value.Position.Z);
+        AssertClose(anchorRotation + MathF.PI, rearMove.Value.Rotation);
     }
 
     [Fact]
@@ -495,4 +540,13 @@ public class FormationExecutionTests
 
     private static void AssertClose(float expected, float actual, float tolerance = 0.0001f) =>
         Assert.InRange(MathF.Abs(expected - actual), 0f, tolerance);
+
+    private static Vector3 ApplyLeaderRotation(Vector3 offset, float leaderRotRad, Vector3 leaderPos) {
+        float cos = MathF.Cos(leaderRotRad);
+        float sin = MathF.Sin(leaderRotRad);
+        return new Vector3(
+            offset.X * cos + offset.Z * sin,
+            offset.Y,
+            -offset.X * sin + offset.Z * cos) + leaderPos;
+    }
 }

--- a/MasterOfPuppetsTests/FormationExecutionTests.cs
+++ b/MasterOfPuppetsTests/FormationExecutionTests.cs
@@ -418,6 +418,87 @@ public class FormationExecutionTests
     }
 
     [Fact]
+    public void FormationMath_GetFormationFrameRotation_SubtractsAnchorPointAngle() {
+        var pointOne = new FormationPoint { Angle = 0f };
+        var pointFour = new FormationPoint { Angle = -135f };
+        var formationFrameRotation = 0.25f;
+        var pointFourActorRotation = formationFrameRotation + pointFour.Angle * Angle.DegToRad;
+
+        AssertClose(formationFrameRotation, FormationMath.GetFormationFrameRotation(pointOne, formationFrameRotation));
+        AssertClose(formationFrameRotation, FormationMath.GetFormationFrameRotation(pointFour, pointFourActorRotation));
+    }
+
+    [Fact]
+    public void FormationMath_ReanchoringCircleFromPointFour_PreservesWorldPlacement() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Offset = new Vector3(-2.1855695E-07f, 0f, 0f), Angle = 1.5258789E-05f },
+                new FormationPoint { Offset = new Vector3(3.535534f, 0f, 1.4644661f), Angle = -45f },
+                new FormationPoint { Offset = new Vector3(5f, 0f, 5f), Angle = -90f },
+                new FormationPoint { Offset = new Vector3(3.5355341f, 0f, 8.535534f), Angle = -135f },
+                new FormationPoint { Offset = new Vector3(-2.1855695E-07f, 0f, 10f), Angle = 180f },
+                new FormationPoint { Offset = new Vector3(-3.535534f, 0f, 8.535534f), Angle = 135f },
+                new FormationPoint { Offset = new Vector3(-5f, 0f, 5.000001f), Angle = 90.000015f },
+                new FormationPoint { Offset = new Vector3(-3.5355332f, 0f, 1.4644656f), Angle = 45f },
+            ],
+        };
+        var originalAnchor = formation.Points[0];
+        var pointFourAnchor = formation.Points[3];
+        var originPosition = new Vector3(10f, 0f, 20f);
+        var formationFrameRotation = 0f;
+
+        var originalWorld = formation.Points
+            .Select(point => FormationMath.GetMopRelativeWorld(
+                originalAnchor,
+                point,
+                originPosition,
+                formationFrameRotation))
+            .ToArray();
+        var pointFourFrameRotation = FormationMath.GetFormationFrameRotation(
+            pointFourAnchor,
+            originalWorld[3].Rotation);
+
+        for (var i = 0; i < formation.Points.Count; i++) {
+            var actual = FormationMath.GetMopRelativeWorld(
+                pointFourAnchor,
+                formation.Points[i],
+                originalWorld[3].Position,
+                pointFourFrameRotation);
+
+            AssertClose(originalWorld[i].Position.X, actual.Position.X, 0.00001f);
+            AssertClose(originalWorld[i].Position.Z, actual.Position.Z, 0.00001f);
+            AssertClose(originalWorld[i].Rotation, actual.Rotation, 0.00001f);
+        }
+    }
+
+    [Fact]
+    public void FormationLocalMovementExecutor_ResolveAnchorFrameRotation_NormalizesOnlyAssignedActorAnchors() {
+        var formation = new Formation {
+            Points = [
+                new FormationPoint { Angle = 0f },
+                new FormationPoint { Angle = -135f },
+            ],
+        };
+        var formationFrameRotation = 0.25f;
+        var actorRotation = formationFrameRotation + formation.Points[1].Angle * Angle.DegToRad;
+
+        AssertClose(
+            formationFrameRotation,
+            FormationLocalMovementExecutor.ResolveAnchorFrameRotation(
+                formation,
+                anchorPointIndex: 1,
+                anchorActorRotation: actorRotation,
+                normalizeAssignedAnchorRotation: true));
+        AssertClose(
+            actorRotation,
+            FormationLocalMovementExecutor.ResolveAnchorFrameRotation(
+                formation,
+                anchorPointIndex: 1,
+                anchorActorRotation: actorRotation,
+                normalizeAssignedAnchorRotation: false));
+    }
+
+    [Fact]
     public void FormationAnchorArgumentParser_ParsesSender() {
         var result = FormationAnchorArgumentParser.ParseAnchorAndArrival(
             ["sender"],

--- a/MasterOfPuppetsTests/FormationImportTests.cs
+++ b/MasterOfPuppetsTests/FormationImportTests.cs
@@ -101,7 +101,7 @@ public class FormationImportTests {
             anchorWorldRotation);
         AssertClose(anchorWorldPosition.X, anchorPosition.X);
         AssertClose(anchorWorldPosition.Z, anchorPosition.Z);
-        AssertClose(anchorWorldRotation, anchorRotation);
+        AssertClose(anchorWorldRotation + 45f * Angle.DegToRad, anchorRotation);
 
         var (memberPosition, memberRotation) = FormationMath.GetMopRelativeWorld(
             anchor,
@@ -111,7 +111,7 @@ public class FormationImportTests {
         var expectedMemberPosition = ApplyLeaderRotation(member.Offset - anchor.Offset, anchorWorldRotation, anchorWorldPosition);
         AssertClose(expectedMemberPosition.X, memberPosition.X);
         AssertClose(expectedMemberPosition.Z, memberPosition.Z);
-        AssertClose(anchorWorldRotation - 90f * Angle.DegToRad, memberRotation);
+        AssertClose(anchorWorldRotation - 45f * Angle.DegToRad, memberRotation);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes formation rotation when the anchor is a character assigned to a non-center formation point (e.g. broadcasting mopformation from point 4 of a circle formation).

## Problem
FormationMath.GetMopRelativeWorld was changed to a rigid rotation, but the anchor rotation passed in was the actor raw world rotation. When the anchor character was assigned to an outer formation point with a non-zero saved angle, the whole formation was twisted by that angle, so switching the broadcaster from point 1 to point 4 caused everyone to move.

## Fix
- Added FormationMath.GetFormationFrameRotation to normalize an actor world rotation by subtracting its assigned formation point saved angle.
- FormationLocalMovementExecutor.ExecuteChatSyncedFormation now normalizes the anchor rotation for Sender/Target/Named anchors that resolve to an assigned character.
- IpcProvider.TryGetFormationAnchor normalizes the rotation for Self/Sender/Named anchors in the IPC path.
- Point 1 / Self anchors are unaffected because their saved angle is 0.

## Tests
- Updated existing rigid-rotation assertions.
- Added FormationMath_GetFormationFrameRotation_SubtractsAnchorPointAngle.
- Added FormationMath_ReanchoringCircleFromPointFour_PreservesWorldPlacement to verify that re-anchoring a circle from point 4 produces identical world positions/rotations for every point.
- Added FormationLocalMovementExecutor_ResolveAnchorFrameRotation_NormalizesOnlyAssignedActorAnchors.

Also fixes CID resolution for named anchors in the IPC path.